### PR TITLE
Check 16 bit overflow on merge

### DIFF
--- a/src/main/java/client/command/commands/gm6/MergeCommand.java
+++ b/src/main/java/client/command/commands/gm6/MergeCommand.java
@@ -386,7 +386,8 @@ public class MergeCommand extends Command {
                     .orElse(getter.apply(primaryItem));
 
             short additionalStat = (short) (currentMaxStat * scalingFactor * (Math.sqrt(equips.size())));
-            short newStatValue = (short) (currentMaxStat + additionalStat);
+            // check 16 bit overflow
+            short newStatValue = (short) (currentMaxStat + additionalStat > currentMaxStat ? currentMaxStat + additionalStat : currentMaxStat);
 
             log.info("The new Item stat for {} is {}", statName, newStatValue);
             statUpdaters.get(statName).accept(primaryItem, newStatValue);


### PR DESCRIPTION
## Description
Simple check to prevent number from overflowing. Return original value if new value overflows. Optionally, just set it to `32767` which should be the true max value.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have tested my changes
- [ ] I have added unit tests that prove my changes work

I don't have any knowledge on Java and how to run this. But it should be correct.