### PR TITLE
Update SellCommand.java

### DIFF
--- a/src/main/java/client/command/commands/gm0/SellCommand.java
+++ b/src/main/java/client/command/commands/gm0/SellCommand.java
@@ -1,82 +1,135 @@
-/*
-    This file is part of the HeavenMS MapleStory Server, commands OdinMS-based
-    Copyleft (L) 2016 - 2019 RonanLana
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-/*
-   @Author: Roey Zeldin - command to sell all slots
-*/
 package client.command.commands.gm0;
 
 import client.Character;
 import client.Client;
 import client.command.Command;
+import client.inventory.Inventory;
 import client.inventory.InventoryType;
 import client.inventory.Item;
+import server.ItemInformationProvider;
 import server.Shop;
 import server.ShopFactory;
 
 import java.util.Arrays;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class SellCommand extends Command {
     {
-        setDescription("Sells all items in an inventory tab, can set max slot number to sell");
+        setDescription("Sells all items in an inventory tab or a specific item by name.");
     }
+
     @Override
     public void execute(Client c, String[] params) {
         Character player = c.getPlayer();
+
         if (params.length < 1) {
-            player.yellowMessage("Syntax: @sell <all, equip, use, setup, etc or cash> <sell slot amount>");
+            player.yellowMessage("Syntax: @sell <all/equip/use/etc/setup/cash/item> [item_name or sell slot amount]");
             return;
         }
-        String type = params[0];
-        Shop shop = ShopFactory.getInstance().getShop(1337); // this is the GM shop
+
+        String type = params[0].toLowerCase();
+        Shop shop = ShopFactory.getInstance().getShop(1337); // GM Shop
         int sellSlotAmount = 101;
-        if (params.length >= 2) {
-            sellSlotAmount = Integer.parseInt(params[1]);
-        }
-        boolean isAll = type.equals("all");
-        if (!allTypesAsString.contains(type.toLowerCase())) {
-            player.yellowMessage("Error: The specified slot type '" + type + "' does not exist.");
+
+        if (type.equals("item")) {
+            if (params.length < 2) {
+                player.yellowMessage("Syntax: @sell item <item_name> [amount]");
+                return;
+            }
+
+            String itemName = String.join(" ", Arrays.copyOfRange(params, 1, params.length - 1)).toLowerCase();
+            int amount = params.length > 2 ? Integer.parseInt(params[params.length - 1]) : 0; // Amount can be passed after item name
+            sellItemByName(c, shop, player, itemName, amount);
             return;
         }
+
+        if (!allTypesAsString.contains(type)) {
+            player.yellowMessage("Error: The specified inventory type '" + type + "' does not exist.");
+            return;
+        }
+
+        if (params.length >= 2) {
+            try {
+                sellSlotAmount = Integer.parseInt(params[1]);
+            } catch (NumberFormatException e) {
+                player.yellowMessage("Invalid slot amount. Using default value: 101.");
+            }
+        }
+
+        boolean isAll = type.equals("all");
+
         for (InventoryType inventoryType : allTypes) {
             if (isAll || inventoryType.name().toLowerCase().equals(type)) {
                 if (isAll && inventoryType == InventoryType.CASH) {
-                    continue;
+                    continue; // Skip selling Cash inventory
                 }
-                for (short i = 0; i <= sellSlotAmount; i++) {
-                    Item tempItem = c.getPlayer().getInventory(inventoryType).getItem((byte) i);
+
+                Inventory inventory = player.getInventory(inventoryType);
+
+                player.yellowMessage("Processing " + inventoryType.name() + " inventory...");
+
+                for (short i = 0; i < inventory.getSlotLimit(); i++) {
+                    Item tempItem = inventory.getItem((byte) i);
                     if (tempItem != null) {
+                        player.yellowMessage("Found item: ID " + tempItem.getItemId() + " in slot " + i);
                         shop.sell(c, inventoryType, i, tempItem.getQuantity());
                     }
                 }
-                if (!isAll) { // quick break
-                    player.yellowMessage("Slot" + type + " sold!");
-                    return;  // Early return after clearing the specific type
+
+                if (!isAll) {
+                    player.yellowMessage("Sold all items in " + type + " inventory!");
+                    return;
                 }
             }
         }
-        player.yellowMessage("All slots sold!");
+        player.yellowMessage("All applicable inventory items have been sold!");
+    }
+
+    private void sellItemByName(Client c, Shop shop, Character player, String itemName, int amount) {
+        ItemInformationProvider itemInfoProvider = ItemInformationProvider.getInstance();
+        boolean itemFound = false;
+
+        player.yellowMessage("Searching for item: " + itemName);
+
+        String lowerCaseItemName = itemName.toLowerCase();
+
+        for (InventoryType inventoryType : allTypes) {
+            Inventory inventory = player.getInventory(inventoryType);
+
+            for (byte i = 0; i < inventory.getSlotLimit(); i++) {
+                Item tempItem = inventory.getItem(i);
+                if (tempItem != null) {
+                    String tempItemName = itemInfoProvider.getName(tempItem.getItemId());
+
+                    if (tempItemName != null) {
+                        String lowerCaseTempItemName = tempItemName.toLowerCase();
+
+                        // Compare item names without considering case
+                        if (lowerCaseTempItemName.equals(lowerCaseItemName)) {
+                            short quantityInStack = tempItem.getQuantity();
+                            short quantityToSell = (short) Math.min(amount, quantityInStack); // Cast to short to avoid type issue
+
+                            player.yellowMessage("Selling " + quantityToSell + " of " + tempItemName);
+                            shop.sell(c, inventoryType, i, quantityToSell);
+
+                            amount -= quantityToSell; // Decrease the remaining amount to sell
+                            itemFound = true;
+
+                            if (amount <= 0) {
+                                player.yellowMessage("Sold " + itemName + "!");
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!itemFound) {
+            player.yellowMessage("No items found with the name '" + itemName + "'.");
+        }
     }
 
     private final InventoryType[] allTypes = {InventoryType.EQUIP, InventoryType.USE, InventoryType.ETC, InventoryType.SETUP, InventoryType.CASH};
-    private final Set<String> allTypesAsString = Set.of("equip", "use", "setup", "etc", "cash", "all");
+    private final Set<String> allTypesAsString = Set.of("equip", "use", "setup", "etc", "cash", "all", "item");
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Added ability to sell a specific amount of an item stack: Users can now specify how many items to sell (e.g., @sell red potion 50).

Exact item name matching: Prevents selling items that are part of another item’s name (e.g., "bow" will not match "arrow for bow").

Improved error handling: Validates item amount input and ensures users cannot sell more than available in the stack.

Retained inventory type selling: Users can still sell items by specific inventory types or all items (@sell equip, @sell all, etc.).

player can sell using @sell item Red potion to sell specific item
or @sell item Red potion 50 

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [ X ] I have performed a self-review of my code
- [ X ] I have tested my changes

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
![image_2025-03-08_212828358](https://github.com/user-attachments/assets/6f1b09e9-4a65-4535-8c72-33180095a534)
