### PR TITLE
Add storage for resources

### DIFF
--- a/scripts/npc/coinStorage.js
+++ b/scripts/npc/coinStorage.js
@@ -1,0 +1,140 @@
+/**
+ * Talking Snow Man
+ * Merge coin storage system
+ * @author CPURules
+ */
+
+var header = "#r#eMerge Coin Storage#k#n\r\n\r\n";
+
+var status;
+
+var actionType; // 0 -> Withdraw, 1 -> Deposit
+var itemId = 2022280;
+
+function start() {
+    status = -1;
+    action(1, 0, 0);
+}
+
+function itemStr(id) {
+    return ("#v" + id + "# #t" + id + "#");
+}
+
+function action(mode, type, selection) {
+    if (mode == -1 || (mode == 0 && status == 0)) {
+        cm.dispose();
+        return;
+    } else if (mode == 0) {
+        status--;
+    } else {
+        status++;
+    }
+
+    var textList = [];
+    textList.push(header);
+    if (status == 0) { // main menu (select transaction type)
+        textList.push("This system can be used to store merge coins (#b" + itemStr(itemId) + "#k).\r\n\r\n");
+        textList.push("What would you like to do?\r\n");
+        textList.push("#b");
+        textList.push("#L0#Withdraw merge coins\r\n");
+        textList.push("#L1#Deposit merge coins#l");
+
+        cm.sendSimple(textList.join(""));
+    } else if (status == 1) { // show current balance and prompt for quantity
+        if (mode == -1) { // if we end chat from the final screen, we exit the npc
+            cm.dispose();
+        } else if (mode == 1) {
+            actionType = selection;
+        }
+
+        if (actionType == 0) { // withdraw
+            var resourceStorage = cm.getPlayer().getResourceStorage()[2];
+            var items = resourceStorage.getItems();
+
+            if (items.size() == 0) {
+                textList.push("It looks like you don't have any merge coins stored right now...\r\n\r\n");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+                return;
+            }
+
+            var qty = items[0].getQuantity();
+            textList.push("You currently have #b#e" + qty + "#n " + itemStr(itemId) + "#k stored.\r\n\r\n");
+            textList.push("How many would you like to withdraw?\r\n");
+            cm.sendGetNumber(textList.join(""), qty, 1, qty);
+        }
+        else if (actionType == 1) { // deposit
+            const InventoryType = Java.type('client.inventory.InventoryType');
+            var qty = cm.getPlayer().getInventory(InventoryType.USE).getMergeCoins();
+            if (qty == 0) {
+                textList.push("It looks like you don't have any merge coins on you right now...\r\n\r\n");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+                return;
+            }
+
+            textList.push("You currently have #b#e" + qty + "#n " + itemStr(itemId) + "#k in your inventory.\r\n\r\n");
+            textList.push("How many would you like to deposit?\r\n");
+            cm.sendGetNumber(textList.join(""), qty, 1, qty);
+        }
+        else { // safeguard
+            cm.dispose();
+        }
+    } else if (status == 2) { // process transaction
+        var qty = selection;
+        var resourceStorage = cm.getPlayer().getResourceStorage()[2];
+        var item = resourceStorage.getItemById(itemId);
+
+        if (actionType == 0) { // withdraw
+            if (item == null || item.getQuantity() < qty) {
+                textList.push("It looks like you don't have enough #b" + itemStr(item) + "#k to withdraw!");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+                return;
+            }
+
+            var newInvItem = cm.gainItem(itemId, qty, false, true);
+            if (newInvItem == null) {
+                textList.push("It looks like you don't have room for this in your inventory...");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+                return;
+            }
+
+            if (resourceStorage.takeOut(item, qty)) {
+                textList.push("Withdrew " + qty + " #b" + itemStr(itemId) + "#k!");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+            }
+            else {
+                cm.sendOk("Uhoh!!!");
+                cm.dispose();
+            }
+        }
+        else if (actionType == 1) { // deposit
+            const InventoryType = Java.type('client.inventory.InventoryType');
+            var inv = cm.getPlayer().getInventory(InventoryType.USE);
+            var item = inv.findById(itemId);
+
+            if (item == null || item.getQuantity() < qty) {
+                cm.sendOk("It looks like you don't have enough #b" + itemStr(itemId) + "#k to deposit!");
+                cm.dispose();
+                return;
+            }
+
+            if (resourceStorage.store(item, qty)) {
+                cm.gainItem(itemId, -1 * qty, false, true);
+                textList.push("Deposited " + qty + " #b" + itemStr(itemId) + "#k!");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+            }
+            else {
+                cm.sendOk("It looks like your storage might be full!");
+                cm.dispose();
+            }
+        }
+    }
+    else {
+        cm.dispose();
+    }
+}

--- a/scripts/npc/coinStorage.js
+++ b/scripts/npc/coinStorage.js
@@ -94,9 +94,7 @@ function action(mode, type, selection) {
             }
 
             var newInvItem = cm.gainItem(itemId, qty, false, true);
-            if (newInvItem == null) {
-                textList.push("It looks like you don't have room for this in your inventory...");
-                cm.sendOk(textList.join(""));
+            if (newInvItem == null) { // no room in inventory, client will display a prompt
                 cm.dispose();
                 return;
             }
@@ -104,10 +102,6 @@ function action(mode, type, selection) {
             if (resourceStorage.takeOut(item, qty)) {
                 textList.push("Withdrew " + qty + " #b" + itemStr(itemId) + "#k!");
                 cm.sendOk(textList.join(""));
-                cm.dispose();
-            }
-            else {
-                cm.sendOk("Uhoh!!!");
                 cm.dispose();
             }
         }

--- a/scripts/npc/coinStorage.js
+++ b/scripts/npc/coinStorage.js
@@ -3,7 +3,7 @@
  * Merge coin storage system
  * @author CPURules
  */
-
+const ResourceStorageType = Java.type('server.ResourceStorage');
 var header = "#r#eMerge Coin Storage#k#n\r\n\r\n";
 
 var status;
@@ -48,7 +48,7 @@ function action(mode, type, selection) {
         }
 
         if (actionType == 0) { // withdraw
-            var resourceStorage = cm.getPlayer().getResourceStorage()[2];
+            var resourceStorage = cm.getPlayer().getResourceStorage()[ResourceStorageType.MERGE_COIN_OFFSET];
             var items = resourceStorage.getItems();
 
             if (items.size() == 0) {
@@ -82,7 +82,7 @@ function action(mode, type, selection) {
         }
     } else if (status == 2) { // process transaction
         var qty = selection;
-        var resourceStorage = cm.getPlayer().getResourceStorage()[2];
+        var resourceStorage = cm.getPlayer().getResourceStorage()[ResourceStorageType.MERGE_COIN_OFFSET];
         var item = resourceStorage.getItemById(itemId);
 
         if (actionType == 0) { // withdraw

--- a/scripts/npc/oreStorage.js
+++ b/scripts/npc/oreStorage.js
@@ -4,8 +4,9 @@
  * @author CPURules
  */
 
-var header = "#r#eCrafting Materials Storage#k#n\r\n\r\n";
+const ResourceStorageType = Java.type('server.ResourceStorage');
 
+var header = "#r#eCrafting Materials Storage#k#n\r\n\r\n";
 var status;
 
 var actionType; // 0 -> Withdraw, 1 -> Deposit
@@ -51,7 +52,7 @@ function action(mode, type, selection) {
         }
 
         if (actionType == 0) { // withdraw
-            var resourceStorage = cm.getPlayer().getResourceStorage()[0];
+            var resourceStorage = cm.getPlayer().getResourceStorage()[ResourceStorageType.ORE_OFFSET];
             var items = resourceStorage.getItems();
 
             if (items.size() == 0) {
@@ -100,7 +101,7 @@ function action(mode, type, selection) {
         }
 
         if (actionType == 0) { // withdraw
-            var resourceStorage = cm.getPlayer().getResourceStorage()[0];
+            var resourceStorage = cm.getPlayer().getResourceStorage()[ResourceStorageType.ORE_OFFSET];
             var item = resourceStorage.getItemById(selectedItem);
             
             textList.push("How many #b" + itemStr(selectedItem) + "#k would you like to withdraw?\r\n");
@@ -119,7 +120,7 @@ function action(mode, type, selection) {
         }
     } else if (status == 3) { // process transaction
         var qty = selection;
-        var resourceStorage = cm.getPlayer().getResourceStorage()[0];
+        var resourceStorage = cm.getPlayer().getResourceStorage()[ResourceStorageType.ORE_OFFSET];
         var item = resourceStorage.getItemById(selectedItem);
 
         if (actionType == 0) { // withdraw

--- a/scripts/npc/oreStorage.js
+++ b/scripts/npc/oreStorage.js
@@ -141,10 +141,6 @@ function action(mode, type, selection) {
                 cm.sendOk(textList.join(""));
                 cm.dispose();
             }
-            else {
-                cm.sendOk("Uhoh!!!");
-                cm.dispose();
-            }
         }
         else if (actionType == 1) { // deposit
             const InventoryType = Java.type('client.inventory.InventoryType');

--- a/scripts/npc/oreStorage.js
+++ b/scripts/npc/oreStorage.js
@@ -1,0 +1,177 @@
+/**
+ * Crystal of Roots
+ * Crafting materials storage system
+ * @author CPURules
+ */
+
+var header = "#r#eCrafting Materials Storage#k#n\r\n\r\n";
+
+var status;
+
+var actionType; // 0 -> Withdraw, 1 -> Deposit
+var selectedItem; // Item ID to withdraw / deposit
+
+function start() {
+    status = -1;
+    action(1, 0, 0);
+}
+
+function itemStr(id) {
+    return ("#v" + id + "# #t" + id + "#");
+}
+
+function action(mode, type, selection) {
+    if (mode == -1 || (mode == 0 && status == 0)) {
+        cm.dispose();
+        return;
+    } else if (mode == 0) {
+        status--;
+    } else {
+        status++;
+    }
+
+    var textList = [];
+    textList.push(header);
+    if (status == 0) { // main menu (select transaction type)
+        textList.push("This system can be used to store any of the following types of items:\r\n");
+        textList.push("\tOres (including refined and strengthened plates/jewels)\r\n");
+        textList.push("\tMonster Crystals\r\n");
+        textList.push("\tMagic Powders\r\n");
+        textList.push("\tCrafting Stimulators and Production Manuals\r\n");
+        textList.push("\t#b" + itemStr(4020009) + "#k and #b" + itemStr(4021010) + "#k\r\n\r\n");
+        textList.push("What would you like to do?\r\n");
+        textList.push("#b");
+        textList.push("#L0#Withdraw materials#l\r\n");
+        textList.push("#L1#Deposit materials#l");
+
+        cm.sendSimple(textList.join(""));
+    } else if (status == 1) { // list items available for deposit/withdraw
+        if (mode == 1) { // if we chose an action, set the action type (allows for backing up)
+            actionType = selection;
+        }
+
+        if (actionType == 0) { // withdraw
+            var resourceStorage = cm.getPlayer().getResourceStorage()[0];
+            var items = resourceStorage.getItems();
+
+            if (items.size() == 0) {
+                textList.push("It looks like you don't have any crafting materials stored right now...\r\n\r\n");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+                return;
+            }
+
+            textList.push("Below are the crafting materials you currently have stored.\r\n\r\n");
+            textList.push("What would you like to withdraw?\r\n");
+            for (var i = 0; i < items.size(); i++) {
+                var item = items[i];
+                var id = item.getItemId();
+                textList.push("#b#L" + id + "#" + itemStr(id) + "#k (" + item.getQuantity() + ")#l\r\n");
+            }
+            cm.sendSimple(textList.join(""));
+        }
+        else if (actionType == 1) { // deposit
+            const InventoryType = Java.type('client.inventory.InventoryType');
+            var inv = cm.getPlayer().getInventory(InventoryType.ETC).getOres();
+            if (inv.size() == 0) {
+                textList.push("It looks like you don't have any crafting materials on you right now...\r\n\r\n");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+                return;
+            }
+
+            textList.push("Below are the crafting materials currently in your inventory.\r\n\r\n");
+            textList.push("What would you like to deposit?\r\n");
+            for (var i = 0; i < inv.size(); i++) {
+                var item = inv[i];
+                var id = item.getItemId();
+                textList.push("#b#L" + id + "# " + itemStr(id) + "#k (" + item.getQuantity() + ")#l\r\n");
+            }
+            cm.sendSimple(textList.join(""));
+        }
+        else { // safeguard
+            cm.dispose();
+        }
+    } else if (status == 2) { // prompt for quantity
+        if (mode == -1) { // if we end chat from the final screen, we exit the npc
+        cm.dispose();
+        } else if (mode == 1) {
+            selectedItem = selection;
+        }
+
+        if (actionType == 0) { // withdraw
+            var resourceStorage = cm.getPlayer().getResourceStorage()[0];
+            var item = resourceStorage.getItemById(selectedItem);
+            
+            textList.push("How many #b" + itemStr(selectedItem) + "#k would you like to withdraw?\r\n");
+            cm.sendGetNumber(textList.join(""), item.getQuantity(), 1, item.getQuantity());
+        }
+        else if (actionType == 1) { // deposit
+            const InventoryType = Java.type('client.inventory.InventoryType');
+            var inv = cm.getPlayer().getInventory(InventoryType.ETC);
+            var item = inv.findById(selectedItem);
+
+            textList.push("How many #b" + itemStr(selectedItem) + "#k would you like to deposit?\r\n");
+            cm.sendGetNumber(textList.join(""), item.getQuantity(), 1, item.getQuantity());
+        }
+        else { // safeguard
+            cm.dispose();
+        }
+    } else if (status == 3) { // process transaction
+        var qty = selection;
+        var resourceStorage = cm.getPlayer().getResourceStorage()[0];
+        var item = resourceStorage.getItemById(selectedItem);
+
+        if (actionType == 0) { // withdraw
+            if (item == null || item.getQuantity() < qty) {
+                textList.push("It looks like you don't have enough #b" + itemStr(selectedItem) + "#k to withdraw!");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+                return;
+            }
+
+            var newInvItem = cm.gainItem(selectedItem, qty, false, true);
+            if (newInvItem == null) {
+                textList.push("It looks like you don't have room for this in your inventory...");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+                return;
+            }
+
+            if (resourceStorage.takeOut(item, selection)) {
+                textList.push("Withdrew " + qty + " #b" + itemStr(selectedItem) + "#k!");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+            }
+            else {
+                cm.sendOk("Uhoh!!!");
+                cm.dispose();
+            }
+        }
+        else if (actionType == 1) { // deposit
+            const InventoryType = Java.type('client.inventory.InventoryType');
+            var inv = cm.getPlayer().getInventory(InventoryType.ETC);
+            var item = inv.findById(selectedItem);
+
+            if (item == null || item.getQuantity() < qty) {
+                cm.sendOk("It looks like you don't have enough #b" + itemStr(selectedItem) + "#k to deposit!");
+                cm.dispose();
+                return;
+            }
+
+            if (resourceStorage.store(item, selection)) {
+                cm.gainItem(selectedItem, -1 * qty, false, true);
+                textList.push("Deposited " + qty + " #b" + itemStr(selectedItem) + "#k!");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+            }
+            else {
+                cm.sendOk("It looks like your storage might be full!");
+                cm.dispose();
+            }
+        }
+    }
+    else {
+        cm.dispose();
+    }
+}

--- a/scripts/npc/oreStorage.js
+++ b/scripts/npc/oreStorage.js
@@ -131,9 +131,7 @@ function action(mode, type, selection) {
             }
 
             var newInvItem = cm.gainItem(selectedItem, qty, false, true);
-            if (newInvItem == null) {
-                textList.push("It looks like you don't have room for this in your inventory...");
-                cm.sendOk(textList.join(""));
+            if (newInvItem == null) { // inventory is full, client will display message, just quit
                 cm.dispose();
                 return;
             }

--- a/scripts/npc/resourceStorage.js
+++ b/scripts/npc/resourceStorage.js
@@ -27,7 +27,7 @@ function action(mode, type, selection) {
         textList.push("#r#eResource Storage Menu#k#n\r\n\r\n");
         textList.push("Welcome to the account-wide resource storage system!  This storage acts as a safe place to store various materials you may find throughout your journey.  ");
         textList.push("This includes ores, scrolls, and merge coins.\r\n\r\n");
-        listText.push("Any eligible resources you loot will automatically be transferred to this storage system from your inventory.  Use #r@togglestore#k to change this setting.\r\n\r\n");
+        textList.push("Any eligible resources you loot will automatically be transferred to this storage system from your inventory.  Use #r@togglestore#k to change this setting.\r\n\r\n");
         textList.push("Which system would you like to access?\r\n");
         textList.push("#b");
         textList.push("#L0#Crafting material storage#l\r\n");

--- a/scripts/npc/resourceStorage.js
+++ b/scripts/npc/resourceStorage.js
@@ -1,127 +1,47 @@
 /**
  * T-1337 Resource Manager
- * Manages account-wide storage of crafting items (ores, monster powder, ..), scrolls,
- * and merge coins
- *Reworked to be resource storage
- *@author CPURules
+ * Main menu for account-wide resource storage (ores; scrolls; merge coins)
+ * @author CPURules
  */
 
- var status = 0;
- var sel;
- var storageType;
- var actionType;
+var status;
 
- var headers = [
-    "#r#eOre Storage#k#n",
-    "#b#eScroll Storage#k#n",
-    "#d#eMerge Coin Storage#k#n"
- ]
+function start() {
+    status = -1;
+    action(1, 0, 0);
+}
 
- function start() {
-     cm.sendSimple("I'm the new storage manager!\r\n\r\n"
-                    + "#b#L0#Ore Storage\r\n"
-                    + "#b#L1#Scroll Storage\r\n"
-                    + "#b#L2#Merge Coin Storage");
- }
- 
- function action(mode, type, selection) {
-     if (mode == -1) {
-         cm.dispose();
-     } else {
-         if (mode == 0 && status == 0) {
-             cm.dispose();
-             return;
-         }
-         if (mode == 1) {
-             status++;
-         } else {
-             status--;
-         }
- 
-         if (status == 1) {
-             storageType = selection;
+function action(mode, type, selection) {
+    if (mode == -1 || (mode == 0 && status == 0)) {
+        cm.dispose();
+        return;
+    } else if (mode == 0) {
+        status--;
+    } else {
+        status++;
+    }
 
-             var listText = [];
+    var textList = [];
 
-             listText.push(headers[storageType]);
-             if (selection == 0) {
-                listText.push("This system can be used to store any of the following types of items:");
-                listText.push("\tOres (including refined and strengthened plates/jewels)");
-                listText.push("\tMonster Crystals");
-                listText.push("\tMagic Powders");
-                listText.push("\tCrafting Stimulators and Production Manuals");
-                listText.push("\t#b#v4020009# #t4020009##k and #b#v4021010# #t4021010#");
-             }
-             else if (selection == 1) {
-                listText.push("This system can be used to store any equipment enhancing scroll you find on your journey.");
-             }
-             else if (selection == 2) {
-                listText.push("This system can be used to store any #b#v2022280##t2022280##k you find on your journey.");
-            }
-            listText.push("");
-            
-            listText.push("#kPlease select what you would like to do:");
-            listText.push("#b#L0#Withdraw from storage#l");
-            listText.push("#L1#Deposit into storage#l");
-        
-            cm.sendSimple(listText.join("\r\n"));
-         }
-         else if (status == 2) {
-            actionType = selection;
+    if (status == 0) {
+        textList.push("#r#eResource Storage Menu#k#n\r\n\r\n");
+        textList.push("Welcome to the account-wide resource storage system!  This storage acts as a safe place to store various materials you may find throughout your journey.  ");
+        textList.push("This includes ores, scrolls, and merge coins.\r\n\r\n");
+        // listText.push("Any eligible resources you loot will automatically be transferred to this storage system from your inventory.\r\n\r\n");
+        textList.push("Which system would you like to access?\r\n");
+        textList.push("#b");
+        textList.push("#L0#Crafting material storage#l\r\n");
+        textList.push("#L1#Scroll storage#l\r\n");
+        textList.push("#L2#Merge Coin storage#l\r\n");
 
-            var listText = [];
-            listText.push(headers[storageType])
-            if (actionType == 0) {
-                var resourceStorage = cm.getPlayer().getResourceStorage()[storageType];
-                var items = resourceStorage.getItems();
-                var c = items.size();
-
-                listText.push("Below are the items you currently have in storage.  Select one to withdraw.");
-                listText.push("You are currently using #e" + c + "#k slot" + (c == 1 ? "" : "s") + " out of " + resourceStorage.getSlots());
-                listText.push("");
-                for (var i = 0; i < items.size(); i++) {
-                    listText.push("#b#L" + i + "##v" + items[i].getItemId() + "# #t" + items[i].getItemId() + "##l");
-                }   
-                
-                cm.sendSimple(listText.join("\r\n"));
-                cm.dispose();
-            }
-            else if (actionType == 1) {
-                const InventoryType = Java.type('client.inventory.InventoryType');
-                var inv;
-                if (storageType == 0) {
-                    inv = cm.getPlayer().getInventory(InventoryType.ETC);
-                }
-                else {
-                    inv = cm.getPlayer().getInventory(InventoryType.USE);
-                }
-
-                if (storageType < 2) {
-                    var canDeposit;
-                    if (storageType == 0) canDeposit = inv.getOres();
-                    else if (storageType == 1) canDeposit = inv.getScrolls();
-                    listText.push("inv size: " + inv.list().size() + " - deposit size: " + canDeposit.size());
-                    listText.push("Select the item you wish to deposit");
-                    for (var i = 0; i < canDeposit.size(); i++) {
-                        listText.push("#b#L" + i + "##v" + canDeposit[i].getItemId() + "# #t" + canDeposit[i].getItemId() + "##l");
-                    }
-
-                    cm.sendSimple(listText.join("\r\n"));
-                    cm.dispose();
-                }
-                else {
-                    var coins = cm.getPlayer().getInventory(InventoryType.USE).getMergeCoins();
-                    listText.push("You currently have #e" + coins + "#k merge coins.");
-                    listText.push("Enter the number you wish to deposit below.");
-
-                    cm.sendSimple(listText.join("\r\n"));
-                    cm.dispose();
-                }
-            }
-         }
-         else {
-            cm.dispose();
-         }
-     }
- }
- 
+        cm.sendSimple(textList.join(""));
+    } else if (status == 1) {
+        var npcIds = [2083002, 2041016, 9310083];
+        var scriptIds = ["oreStorage", "scrollStorage", "coinStorage"];
+        cm.dispose();
+        cm.openNpc(npcIds[selection], scriptIds[selection]);
+    }
+    else {
+        cm.dispose();
+    }
+}

--- a/scripts/npc/resourceStorage.js
+++ b/scripts/npc/resourceStorage.js
@@ -1,0 +1,89 @@
+/**
+ * T-1337 Resource Manager
+ * Manages account-wide storage of crafting items (ores, monster powder, ..), scrolls,
+ * and merge coins
+ *Reworked to be resource storage
+ *@author CPURules
+ */
+
+ var status = 0;
+ var sel;
+ 
+ function start() {
+     cm.sendSimple("I'm the new storage manager!\r\n\r\n"
+                    + "#b#L0#Ore Storage\r\n"
+                    + "#b#L1#Scroll Storage\r\n"
+                    + "#b#L2#Merge Coin Storage");
+ }
+ 
+ function action(mode, type, selection) {
+     if (mode == -1) {
+         cm.dispose();
+     } else {
+         if (mode == 0 && status == 0) {
+             cm.dispose();
+             return;
+         }
+         if (mode == 1) {
+             status++;
+         } else {
+             status--;
+         }
+ 
+         if (status == 1) {
+             sel = selection;
+ 
+             if (selection == 0) {
+                 cm.sendOk("Ore storage!");
+             }
+             else if (selection == 1) {
+                 cm.sendOk("Scroll storage!");
+             }
+             else if (selection == 2) {
+                 cm.sendOk("Merge Coin storage!");
+             }
+             cm.dispose();
+ 
+             /*
+             if (selection == 0) {
+                 if (cm.getPlayer().getGuildId() > 0) {
+                     cm.sendOk("You may not create a new Guild while you are in one.");
+                     cm.dispose();
+                 } else {
+                     cm.sendYesNo("Creating a Guild costs #b 1500000 mesos#k, are you sure you want to continue?");
+                 }
+             } else if (selection == 1) {
+                 if (cm.getPlayer().getGuildId() < 1 || cm.getPlayer().getGuildRank() != 1) {
+                     cm.sendOk("You can only disband a Guild if you are the leader of that Guild.");
+                     cm.dispose();
+                 } else {
+                     cm.sendYesNo("Are you sure you want to disband your Guild? You will not be able to recover it afterward and all your GP will be gone.");
+                 }
+             } else if (selection == 2) {
+                 if (cm.getPlayer().getGuildId() < 1 || cm.getPlayer().getGuildRank() != 1) {
+                     cm.sendOk("You can only increase your Guild's capacity if you are the leader.");
+                     cm.dispose();
+                 } else {
+                     var Guild = Java.type("net.server.guild.Guild");  // thanks Conrad for noticing an issue due to call on a static method here
+                     cm.sendYesNo("Increasing your Guild capacity by #b5#k costs #b " + Guild.getIncreaseGuildCost(cm.getPlayer().getGuild().getCapacity()) + " mesos#k, are you sure you want to continue?");
+                 }
+             }*/
+         }
+         /*
+         } else if (status == 2) {
+             if (sel == 0 && cm.getPlayer().getGuildId() <= 0) {
+                 cm.getPlayer().genericGuildMessage(1);
+                 cm.dispose();
+             } else if (cm.getPlayer().getGuildId() > 0 && cm.getPlayer().getGuildRank() == 1) {
+                 if (sel == 1) {
+                     cm.getPlayer().disbandGuild();
+                     cm.dispose();
+                 } else if (sel == 2) {
+                     cm.getPlayer().increaseGuildCapacity();
+                     cm.dispose();
+                 }
+             }
+         }*/
+     }
+ }
+ 

--- a/scripts/npc/resourceStorage.js
+++ b/scripts/npc/resourceStorage.js
@@ -27,7 +27,7 @@ function action(mode, type, selection) {
         textList.push("#r#eResource Storage Menu#k#n\r\n\r\n");
         textList.push("Welcome to the account-wide resource storage system!  This storage acts as a safe place to store various materials you may find throughout your journey.  ");
         textList.push("This includes ores, scrolls, and merge coins.\r\n\r\n");
-        // listText.push("Any eligible resources you loot will automatically be transferred to this storage system from your inventory.\r\n\r\n");
+        listText.push("Any eligible resources you loot will automatically be transferred to this storage system from your inventory.  Use #r@togglestore#k to change this setting.\r\n\r\n");
         textList.push("Which system would you like to access?\r\n");
         textList.push("#b");
         textList.push("#L0#Crafting material storage#l\r\n");

--- a/scripts/npc/resourceStorage.js
+++ b/scripts/npc/resourceStorage.js
@@ -8,7 +8,15 @@
 
  var status = 0;
  var sel;
- 
+ var storageType;
+ var actionType;
+
+ var headers = [
+    "#r#eOre Storage#k#n",
+    "#b#eScroll Storage#k#n",
+    "#d#eMerge Coin Storage#k#n"
+ ]
+
  function start() {
      cm.sendSimple("I'm the new storage manager!\r\n\r\n"
                     + "#b#L0#Ore Storage\r\n"
@@ -31,59 +39,89 @@
          }
  
          if (status == 1) {
-             sel = selection;
- 
+             storageType = selection;
+
+             var listText = [];
+
+             listText.push(headers[storageType]);
              if (selection == 0) {
-                 cm.sendOk("Ore storage!");
+                listText.push("This system can be used to store any of the following types of items:");
+                listText.push("\tOres (including refined and strengthened plates/jewels)");
+                listText.push("\tMonster Crystals");
+                listText.push("\tMagic Powders");
+                listText.push("\tCrafting Stimulators and Production Manuals");
+                listText.push("\t#b#v4020009# #t4020009##k and #b#v4021010# #t4021010#");
              }
              else if (selection == 1) {
-                 cm.sendOk("Scroll storage!");
+                listText.push("This system can be used to store any equipment enhancing scroll you find on your journey.");
              }
              else if (selection == 2) {
-                 cm.sendOk("Merge Coin storage!");
-             }
-             cm.dispose();
- 
-             /*
-             if (selection == 0) {
-                 if (cm.getPlayer().getGuildId() > 0) {
-                     cm.sendOk("You may not create a new Guild while you are in one.");
-                     cm.dispose();
-                 } else {
-                     cm.sendYesNo("Creating a Guild costs #b 1500000 mesos#k, are you sure you want to continue?");
-                 }
-             } else if (selection == 1) {
-                 if (cm.getPlayer().getGuildId() < 1 || cm.getPlayer().getGuildRank() != 1) {
-                     cm.sendOk("You can only disband a Guild if you are the leader of that Guild.");
-                     cm.dispose();
-                 } else {
-                     cm.sendYesNo("Are you sure you want to disband your Guild? You will not be able to recover it afterward and all your GP will be gone.");
-                 }
-             } else if (selection == 2) {
-                 if (cm.getPlayer().getGuildId() < 1 || cm.getPlayer().getGuildRank() != 1) {
-                     cm.sendOk("You can only increase your Guild's capacity if you are the leader.");
-                     cm.dispose();
-                 } else {
-                     var Guild = Java.type("net.server.guild.Guild");  // thanks Conrad for noticing an issue due to call on a static method here
-                     cm.sendYesNo("Increasing your Guild capacity by #b5#k costs #b " + Guild.getIncreaseGuildCost(cm.getPlayer().getGuild().getCapacity()) + " mesos#k, are you sure you want to continue?");
-                 }
-             }*/
+                listText.push("This system can be used to store any #b#v2022280##t2022280##k you find on your journey.");
+            }
+            listText.push("");
+            
+            listText.push("#kPlease select what you would like to do:");
+            listText.push("#b#L0#Withdraw from storage#l");
+            listText.push("#L1#Deposit into storage#l");
+        
+            cm.sendSimple(listText.join("\r\n"));
          }
-         /*
-         } else if (status == 2) {
-             if (sel == 0 && cm.getPlayer().getGuildId() <= 0) {
-                 cm.getPlayer().genericGuildMessage(1);
-                 cm.dispose();
-             } else if (cm.getPlayer().getGuildId() > 0 && cm.getPlayer().getGuildRank() == 1) {
-                 if (sel == 1) {
-                     cm.getPlayer().disbandGuild();
-                     cm.dispose();
-                 } else if (sel == 2) {
-                     cm.getPlayer().increaseGuildCapacity();
-                     cm.dispose();
-                 }
-             }
-         }*/
+         else if (status == 2) {
+            actionType = selection;
+
+            var listText = [];
+            listText.push(headers[storageType])
+            if (actionType == 0) {
+                var resourceStorage = cm.getPlayer().getResourceStorage()[storageType];
+                var items = resourceStorage.getItems();
+                var c = items.size();
+
+                listText.push("Below are the items you currently have in storage.  Select one to withdraw.");
+                listText.push("You are currently using #e" + c + "#k slot" + (c == 1 ? "" : "s") + " out of " + resourceStorage.getSlots());
+                listText.push("");
+                for (var i = 0; i < items.size(); i++) {
+                    listText.push("#b#L" + i + "##v" + items[i].getItemId() + "# #t" + items[i].getItemId() + "##l");
+                }   
+                
+                cm.sendSimple(listText.join("\r\n"));
+                cm.dispose();
+            }
+            else if (actionType == 1) {
+                const InventoryType = Java.type('client.inventory.InventoryType');
+                var inv;
+                if (storageType == 0) {
+                    inv = cm.getPlayer().getInventory(InventoryType.ETC);
+                }
+                else {
+                    inv = cm.getPlayer().getInventory(InventoryType.USE);
+                }
+
+                if (storageType < 2) {
+                    var canDeposit;
+                    if (storageType == 0) canDeposit = inv.getOres();
+                    else if (storageType == 1) canDeposit = inv.getScrolls();
+                    listText.push("inv size: " + inv.list().size() + " - deposit size: " + canDeposit.size());
+                    listText.push("Select the item you wish to deposit");
+                    for (var i = 0; i < canDeposit.size(); i++) {
+                        listText.push("#b#L" + i + "##v" + canDeposit[i].getItemId() + "# #t" + canDeposit[i].getItemId() + "##l");
+                    }
+
+                    cm.sendSimple(listText.join("\r\n"));
+                    cm.dispose();
+                }
+                else {
+                    var coins = cm.getPlayer().getInventory(InventoryType.USE).getMergeCoins();
+                    listText.push("You currently have #e" + coins + "#k merge coins.");
+                    listText.push("Enter the number you wish to deposit below.");
+
+                    cm.sendSimple(listText.join("\r\n"));
+                    cm.dispose();
+                }
+            }
+         }
+         else {
+            cm.dispose();
+         }
      }
  }
  

--- a/scripts/npc/scrollStorage.js
+++ b/scripts/npc/scrollStorage.js
@@ -139,10 +139,6 @@ function action(mode, type, selection) {
                 cm.sendOk(textList.join(""));
                 cm.dispose();
             }
-            else {
-                cm.sendOk("Uhoh!!!");
-                cm.dispose();
-            }
         }
         else if (actionType == 1) { // deposit
             const InventoryType = Java.type('client.inventory.InventoryType');

--- a/scripts/npc/scrollStorage.js
+++ b/scripts/npc/scrollStorage.js
@@ -3,7 +3,7 @@
  * Scroll storage system
  * @author CPURules
  */
-
+const ResourceStorageType = Java.type('server.ResourceStorage');
 var header = "#r#eScroll Storage#k#n\r\n\r\n";
 
 var status;
@@ -50,13 +50,14 @@ function action(mode, type, selection) {
         }
 
         if (actionType == 0) { // withdraw
-            var resourceStorage = cm.getPlayer().getResourceStorage()[1];
+            var resourceStorage = cm.getPlayer().getResourceStorage()[ResourceStorageType.SCROLL_OFFSET];
             var items = resourceStorage.getItems();
 
             if (items.size() == 0) {
                 textList.push("It looks like you don't have any scrolls stored right now...\r\n\r\n");
                 cm.sendOk(textList.join(""));
                 cm.dispose();
+                return;
             }
 
             textList.push("Below are the scrolls you currently have stored.\r\n\r\n");
@@ -98,7 +99,7 @@ function action(mode, type, selection) {
         }
 
         if (actionType == 0) { // withdraw
-            var resourceStorage = cm.getPlayer().getResourceStorage()[1];
+            var resourceStorage = cm.getPlayer().getResourceStorage()[ResourceStorageType.SCROLL_OFFSET];
             var item = resourceStorage.getItemById(selectedItem);
             
             textList.push("How many #b" + itemStr(selectedItem) + "#k would you like to withdraw?\r\n");
@@ -117,7 +118,7 @@ function action(mode, type, selection) {
         }
     } else if (status == 3) { // process transaction
         var qty = selection;
-        var resourceStorage = cm.getPlayer().getResourceStorage()[1];
+        var resourceStorage = cm.getPlayer().getResourceStorage()[ResourceStorageType.SCROLL_OFFSET];
         var item = resourceStorage.getItemById(selectedItem);
 
         if (actionType == 0) { // withdraw

--- a/scripts/npc/scrollStorage.js
+++ b/scripts/npc/scrollStorage.js
@@ -72,7 +72,7 @@ function action(mode, type, selection) {
             const InventoryType = Java.type('client.inventory.InventoryType');
             var inv = cm.getPlayer().getInventory(InventoryType.USE).getScrolls();
             if (inv.size() == 0) {
-                textList.push("It looks like you don't have any crafting materials on you right now...\r\n\r\n");
+                textList.push("It looks like you don't have any scrolls materials on you right now...\r\n\r\n");
                 cm.sendOk(textList.join(""));
                 cm.dispose();
                 return;
@@ -129,9 +129,7 @@ function action(mode, type, selection) {
             }
 
             var newInvItem = cm.gainItem(selectedItem, qty, false, true);
-            if (newInvItem == null) {
-                textList.push("It looks like you don't have room for this in your inventory...");
-                cm.sendOk(textList.join(""));
+            if (newInvItem == null) { // inventory is full, client will display message, just quit
                 cm.dispose();
                 return;
             }

--- a/scripts/npc/scrollStorage.js
+++ b/scripts/npc/scrollStorage.js
@@ -1,0 +1,175 @@
+/**
+ * Vega
+ * Scroll storage system
+ * @author CPURules
+ */
+
+var header = "#r#eScroll Storage#k#n\r\n\r\n";
+
+var status;
+
+var actionType; // 0 -> Withdraw, 1 -> Deposit
+var selectedItem; // Item ID to withdraw / deposit
+
+function start() {
+    status = -1;
+    action(1, 0, 0);
+}
+
+function itemStr(id) {
+    return ("#v" + id + "# #t" + id + "#");
+}
+
+function action(mode, type, selection) {
+    if (mode == -1 || (mode == 0 && status == 0)) {
+        cm.dispose();
+        return;
+    } else if (mode == 0) {
+        status--;
+    } else {
+        status++;
+    }
+
+    var textList = [];
+    textList.push(header);
+    if (status == 0) { // main menu (select transaction type)
+        textList.push("This system can be used to store any of the following types of items:\r\n");
+        textList.push("\t#i2041000# Equipment enhancing scrolls\r\n");
+        textList.push("\t#i2049100# Chaos scrolls\r\n");
+        textList.push("\t#i2340000# White scrolls\r\n");
+        textList.push("\t#i2049000# Clean slate scrolls\r\n");
+        textList.push("What would you like to do?\r\n");
+        textList.push("#b");
+        textList.push("#L0#Withdraw scrolls#l\r\n");
+        textList.push("#L1#Deposit scrolls#l");
+
+        cm.sendSimple(textList.join(""));
+    } else if (status == 1) { // list items available for deposit/withdraw
+        if (mode == 1) { // if we chose an action, set the action type (allows for backing up)
+            actionType = selection;
+        }
+
+        if (actionType == 0) { // withdraw
+            var resourceStorage = cm.getPlayer().getResourceStorage()[1];
+            var items = resourceStorage.getItems();
+
+            if (items.size() == 0) {
+                textList.push("It looks like you don't have any scrolls stored right now...\r\n\r\n");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+            }
+
+            textList.push("Below are the scrolls you currently have stored.\r\n\r\n");
+            textList.push("What would you like to withdraw?\r\n");
+            for (var i = 0; i < items.size(); i++) {
+                var item = items[i];
+                var id = item.getItemId();
+                textList.push("#b#L" + id + "#" + itemStr(id) + "#k (" + item.getQuantity() + ")#l\r\n");
+            }
+            cm.sendSimple(textList.join(""));
+        }
+        else if (actionType == 1) { // deposit
+            const InventoryType = Java.type('client.inventory.InventoryType');
+            var inv = cm.getPlayer().getInventory(InventoryType.USE).getScrolls();
+            if (inv.size() == 0) {
+                textList.push("It looks like you don't have any crafting materials on you right now...\r\n\r\n");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+                return;
+            }
+
+            textList.push("Below are the scrolls currently in your inventory.\r\n\r\n");
+            textList.push("What would you like to deposit?\r\n");
+            for (var i = 0; i < inv.size(); i++) {
+                var item = inv[i];
+                var id = item.getItemId();
+                textList.push("#b#L" + id + "# " + itemStr(id) + "#k (" + item.getQuantity() + ")#l\r\n");
+            }
+            cm.sendSimple(textList.join(""));
+        }
+        else { // safeguard
+            cm.dispose();
+        }
+    } else if (status == 2) { // prompt for quantity
+        if (mode == -1) { // if we end chat from the final screen, we exit the npc
+            cm.dispose();
+        } else if (mode == 1) {
+            selectedItem = selection;
+        }
+
+        if (actionType == 0) { // withdraw
+            var resourceStorage = cm.getPlayer().getResourceStorage()[1];
+            var item = resourceStorage.getItemById(selectedItem);
+            
+            textList.push("How many #b" + itemStr(selectedItem) + "#k would you like to withdraw?\r\n");
+            cm.sendGetNumber(textList.join(""), item.getQuantity(), 1, item.getQuantity());
+        }
+        else if (actionType == 1) { // deposit
+            const InventoryType = Java.type('client.inventory.InventoryType');
+            var inv = cm.getPlayer().getInventory(InventoryType.USE);
+            var item = inv.findById(selectedItem);
+
+            textList.push("How many #b" + itemStr(selectedItem) + "#k would you like to deposit?\r\n");
+            cm.sendGetNumber(textList.join(""), item.getQuantity(), 1, item.getQuantity());
+        }
+        else { // safeguard
+            cm.dispose();
+        }
+    } else if (status == 3) { // process transaction
+        var qty = selection;
+        var resourceStorage = cm.getPlayer().getResourceStorage()[1];
+        var item = resourceStorage.getItemById(selectedItem);
+
+        if (actionType == 0) { // withdraw
+            if (item == null || item.getQuantity() < qty) {
+                textList.push("It looks like you don't have enough #b" + itemStr(selectedItem) + "#k to withdraw!");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+                return;
+            }
+
+            var newInvItem = cm.gainItem(selectedItem, qty, false, true);
+            if (newInvItem == null) {
+                textList.push("It looks like you don't have room for this in your inventory...");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+                return;
+            }
+
+            if (resourceStorage.takeOut(item, selection)) {
+                textList.push("Withdrew " + qty + " #b" + itemStr(selectedItem) + "#k!");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+            }
+            else {
+                cm.sendOk("Uhoh!!!");
+                cm.dispose();
+            }
+        }
+        else if (actionType == 1) { // deposit
+            const InventoryType = Java.type('client.inventory.InventoryType');
+            var inv = cm.getPlayer().getInventory(InventoryType.USE);
+            var item = inv.findById(selectedItem);
+
+            if (item == null || item.getQuantity() < qty) {
+                cm.sendOk("It looks like you don't have enough #b" + itemStr(selectedItem) + "#k to deposit!");
+                cm.dispose();
+                return;
+            }
+
+            if (resourceStorage.store(item, selection)) {
+                cm.gainItem(selectedItem, -1 * qty, false, true);
+                textList.push("Deposited " + qty + " #b" + itemStr(selectedItem) + "#k!");
+                cm.sendOk(textList.join(""));
+                cm.dispose();
+            }
+            else {
+                cm.sendOk("It looks like your storage might be full!");
+                cm.dispose();
+            }
+        }
+    }
+    else {
+        cm.dispose();
+    }
+}

--- a/src/main/java/client/AccountExtraDetails.java
+++ b/src/main/java/client/AccountExtraDetails.java
@@ -5,6 +5,7 @@ import java.util.List;
 public class AccountExtraDetails {
     private List<Achievement> achievements;
     private List<String> ascension;
+    private boolean autoStoreOnLoot = true;
 
     // Getters and setters
     public List<Achievement> getAchievements() {
@@ -21,6 +22,15 @@ public class AccountExtraDetails {
 
     public void setAscension(List<String> ascension) {
         this.ascension = ascension;
+    }
+
+    
+    public boolean shouldAutoStoreOnLoot() {
+        return autoStoreOnLoot;
+    }
+
+    public void setAutoStoreOnLoot(boolean autoStoreOnLoot) {
+        this.autoStoreOnLoot = autoStoreOnLoot;
     }
 }
 

--- a/src/main/java/client/Achievement.java
+++ b/src/main/java/client/Achievement.java
@@ -61,7 +61,8 @@ public class Achievement {
         return String.format("""
             {
                 "achievements": %s,
-                "ascension": []
+                "ascension": [],
+                "autoStoreOnLoot": true
             }
             """, new ObjectMapper().valueToTree(getInitialAchievements()).toString());
     }

--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -2100,6 +2100,23 @@ public class Character extends AbstractCharacterObject {
                 Item mItem = mapitem.getItem();
                 boolean hasSpaceInventory = true;
                 ItemInformationProvider ii = ItemInformationProvider.getInstance();
+
+                if (ItemId.isStoreableResource(mapitem.getItemId())) {
+                    int itemId = mapitem.getItemId();
+                    ResourceStorage rs = null;
+                    if (ItemId.isOre(itemId)) rs = getResourceStorage()[0];
+                    else if (ItemId.isScroll(itemId)) rs = getResourceStorage()[1];
+                    else if (ItemId.isMergeCoin(itemId)) rs = getResourceStorage()[2];
+                                    
+                    if (rs != null && rs.store(mItem, mItem.getQuantity())) {
+                        sendPacket(PacketCreator.earnTitleMessage("Sent (" + mItem.getQuantity() + ") "
+                                                                    + ItemInformationProvider.getInstance().getName(itemId)
+                                                                    + " to resource storage!"));
+                        this.getMap().pickItemDrop(pickupPacket, mapitem);
+                        return;
+                    }
+                }
+
                 if (ItemId.isNxCard(mapitem.getItemId()) || mapitem.getMeso() > 0 || ii.isConsumeOnPickup(mapitem.getItemId()) || (hasSpaceInventory = InventoryManipulator.checkSpace(client, mapitem.getItemId(), mItem.getQuantity(), mItem.getOwner()))) {
                     int mapId = this.getMapId();
 

--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -8815,6 +8815,20 @@ public class Character extends AbstractCharacterObject {
                 // Items
                 ItemFactory.INVENTORY.saveItems(itemsWithType, id, con);
 
+                // Resource Storage
+                for (int i = 0; i < resourceStorages.length; i++) {
+                    ItemFactory f = ItemFactory.getFactoryByValue(ItemFactory.STORED_ORES.getValue() + i);
+                    
+                    ResourceStorage rs = resourceStorages[i];
+                    itemsWithType = new ArrayList<>();
+                    for (Item item : rs.getItems()) {
+                        log.info("adding item " + ItemInformationProvider.getInstance().getName(item.getItemId()));
+                        itemsWithType.add(new Pair<>(item, item.getInventoryType()));
+                    }
+                    log.info("Saving storage for " + f.name());
+                    f.saveItems(itemsWithType, accountid, con);
+                }
+
                 // Skills
                 try (PreparedStatement psSkill = con.prepareStatement("REPLACE INTO skills (characterid, skillid, skilllevel, masterlevel, expiration) VALUES (?, ?, ?, ?, ?)")) {
                     psSkill.setInt(1, id);

--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -8822,10 +8822,8 @@ public class Character extends AbstractCharacterObject {
                     ResourceStorage rs = resourceStorages[i];
                     itemsWithType = new ArrayList<>();
                     for (Item item : rs.getItems()) {
-                        log.info("adding item " + ItemInformationProvider.getInstance().getName(item.getItemId()));
                         itemsWithType.add(new Pair<>(item, item.getInventoryType()));
                     }
-                    log.info("Saving storage for " + f.name());
                     f.saveItems(itemsWithType, accountid, con);
                 }
 

--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -111,6 +111,7 @@ import server.Marriage;
 import server.Shop;
 import server.StatEffect;
 import server.Storage;
+import server.ResourceStorage;
 import server.ThreadManager;
 import server.TimerManager;
 import server.Trade;
@@ -279,6 +280,7 @@ public class Character extends AbstractCharacterObject {
     private Shop shop = null;
     private SkinColor skinColor = SkinColor.NORMAL;
     private Storage storage = null;
+    private ResourceStorage[] resourceStorages = new ResourceStorage[3];
     private Trade trade = null;
     private MonsterBook monsterbook;
     private CashShop cashshop;
@@ -6027,6 +6029,10 @@ public class Character extends AbstractCharacterObject {
         return storage;
     }
 
+    public ResourceStorage[] getResourceStorage() {
+        return resourceStorages;
+    }
+
     public Collection<Summon> getSummonsValues() {
         return summons.values();
     }
@@ -7590,6 +7596,7 @@ public class Character extends AbstractCharacterObject {
                 
                 ret.buddylist.loadFromDb(charid);
                 ret.storage = wserv.getAccountStorage(ret.accountid);
+                ret.resourceStorages = wserv.getResourceStorages(ret.accountid);
 
                 /* Double-check storage incase player is first time on server
                  * The storage won't exist so nothing to load
@@ -7597,6 +7604,10 @@ public class Character extends AbstractCharacterObject {
                 if(ret.storage == null) {
                     wserv.loadAccountStorage(ret.accountid);
                     ret.storage = wserv.getAccountStorage(ret.accountid);
+                }
+                if (ret.resourceStorages == null) {
+                    wserv.loadResourceStorage(ret.accountid);
+                    ret.resourceStorages = wserv.getResourceStorages(ret.accountid);
                 }
                 
                 int startHp = ret.hp, startMp = ret.mp;

--- a/src/main/java/client/command/CommandsExecutor.java
+++ b/src/main/java/client/command/CommandsExecutor.java
@@ -57,6 +57,7 @@ import client.command.commands.gm0.StatIntCommand;
 import client.command.commands.gm0.StatLukCommand;
 import client.command.commands.gm0.StatStrCommand;
 import client.command.commands.gm0.TimeCommand;
+import client.command.commands.gm0.ToggleAutoStoreCommand;
 import client.command.commands.gm0.ToggleExpCommand;
 import client.command.commands.gm0.UptimeCommand;
 import client.command.commands.gm0.WarpRandomMap;
@@ -392,6 +393,7 @@ public class CommandsExecutor {
         addCommand("mobhp", MobHpCommand.class);
         addCommand("buyexp", BuyExpCommand.class);
         addCommand("resources", ResourceStorageCommand.class);
+        addCommand("togglestore", ToggleAutoStoreCommand.class);
 
 
         commandsNameDesc.add(levelCommandsCursor);

--- a/src/main/java/client/command/CommandsExecutor.java
+++ b/src/main/java/client/command/CommandsExecutor.java
@@ -46,6 +46,7 @@ import client.command.commands.gm0.RatesCommand;
 import client.command.commands.gm0.ReadPointsCommand;
 import client.command.commands.gm0.ReportBugCommand;
 import client.command.commands.gm0.ResetStatsCommand;
+import client.command.commands.gm0.ResourceStorageCommand;
 import client.command.commands.gm0.RollCommand;
 import client.command.commands.gm0.SellCommand;
 import client.command.commands.gm0.ShopCommand;
@@ -390,6 +391,7 @@ public class CommandsExecutor {
         addCommand("bosshp", BossHpCommand.class);
         addCommand("mobhp", MobHpCommand.class);
         addCommand("buyexp", BuyExpCommand.class);
+        addCommand("resources", ResourceStorageCommand.class);
 
 
         commandsNameDesc.add(levelCommandsCursor);

--- a/src/main/java/client/command/commands/gm0/ResourceStorageCommand.java
+++ b/src/main/java/client/command/commands/gm0/ResourceStorageCommand.java
@@ -1,0 +1,20 @@
+/*
+ * Command to launch resource storage manager NPC (T-1337)
+ * @Author: CPURules
+*/
+package client.command.commands.gm0;
+
+import client.Client;
+import client.command.Command;
+import constants.id.NpcId;
+
+public class ResourceStorageCommand extends Command {
+    {
+        setDescription("Open resource storage (scrolls, ores, merge coins)");
+    }
+
+    @Override
+    public void execute(Client c, String[] params) {
+        c.getAbstractPlayerInteraction().openNpc(NpcId.PLAYER_RESOURCE_STORAGE, "resourceStorage");
+    }
+}

--- a/src/main/java/client/command/commands/gm0/ToggleAutoStoreCommand.java
+++ b/src/main/java/client/command/commands/gm0/ToggleAutoStoreCommand.java
@@ -1,0 +1,27 @@
+package client.command.commands.gm0;
+
+import client.Client;
+import client.command.Command;
+import client.inventory.manipulator.InventoryManipulator;
+import client.Character;
+
+
+public class ToggleAutoStoreCommand extends Command {
+    {
+        setDescription("Toggles auto storage of resource items on loot.");
+    }
+    @Override
+    public void execute(Client c, String[] params) {
+        Character player = c.getPlayer();
+        
+        try {
+            player.toggleAutoStoreOnLoot();
+            player.dropMessage(5, "Toggled resource auto storage.  Currently: "
+                                        + (player.accountExtraDetails.shouldAutoStoreOnLoot() ? "ON" : "OFF"));
+        } catch (Exception e) {
+            player.dropMessage(5, "Unable to toggle resource auto storage setting.");
+        }
+        
+    }
+    
+}

--- a/src/main/java/client/inventory/Inventory.java
+++ b/src/main/java/client/inventory/Inventory.java
@@ -24,6 +24,7 @@ package client.inventory;
 import client.Character;
 import client.Client;
 import client.inventory.manipulator.InventoryManipulator;
+import constants.id.ItemId;
 import constants.inventory.ItemConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,7 @@ import tools.Pair;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -61,6 +63,34 @@ public class Inventory implements Iterable<Item> {
         this.inventory = new LinkedHashMap<>();
         this.type = type;
         this.slotLimit = slotLimit;
+    }
+
+    private List<Item> getSortedByItemName(List<Item> items) {
+        ItemInformationProvider ii = ItemInformationProvider.getInstance();
+        
+        List<Item> ret = new ArrayList<>();
+        for (Item item : items) {
+            ret.add(item);
+        }
+        
+        if (ret.size() > 1) {
+            ret.sort((i1, i2) -> (ii.getName(i1.getItemId()).compareTo(ii.getName(i2.getItemId()))));
+        }
+
+        return ret;
+    }
+
+    public List<Item> getScrolls() {
+        return getSortedByItemName(inventory.values().stream().filter(i -> ItemId.isScroll(i.getItemId())).toList());
+    }
+
+    public List<Item> getOres() {
+        return getSortedByItemName(inventory.values().stream().filter(i -> ItemId.isOre(i.getItemId())).toList());
+    }
+
+    public short getMergeCoins() {
+        List<Item> coins = inventory.values().stream().filter(i -> ItemId.isMergeCoin(i.getItemId())).toList();
+        return (coins.size() == 0) ? 0 : coins.getFirst().getQuantity();
     }
 
     public boolean isExtendableInventory() { // not sure about cash, basing this on the previous one.

--- a/src/main/java/client/inventory/ItemFactory.java
+++ b/src/main/java/client/inventory/ItemFactory.java
@@ -47,7 +47,9 @@ public enum ItemFactory {
     CASH_OVERALL(7, true),
     MARRIAGE_GIFTS(8, false),
     DUEY(9, false),
-    RESOURCE_STORAGE(10, true);
+    STORED_ORES(10, true),
+    STORED_SCROLLS(11, true),
+    STORED_COINS(12, true);
     private final int value;
     private final boolean account;
 
@@ -67,6 +69,15 @@ public enum ItemFactory {
 
     public int getValue() {
         return value;
+    }
+
+    public static ItemFactory getFactoryByValue(int value) {
+        for (ItemFactory factory : ItemFactory.values()) {
+            if (factory.value == value) {
+                return factory;
+            }
+        }
+        return null;
     }
 
     public List<Pair<Item, InventoryType>> loadItems(int id, boolean login) throws SQLException {

--- a/src/main/java/client/inventory/ItemFactory.java
+++ b/src/main/java/client/inventory/ItemFactory.java
@@ -46,7 +46,8 @@ public enum ItemFactory {
     MERCHANT(6, false),
     CASH_OVERALL(7, true),
     MARRIAGE_GIFTS(8, false),
-    DUEY(9, false);
+    DUEY(9, false),
+    RESOURCE_STORAGE(10, true);
     private final int value;
     private final boolean account;
 

--- a/src/main/java/constants/id/ItemId.java
+++ b/src/main/java/constants/id/ItemId.java
@@ -95,6 +95,10 @@ public class ItemId {
         return itemId == MERGE_COIN;
     }
 
+    public static boolean isStoreableResource(int itemId) {
+        return isOre(itemId) || isScroll(itemId) || isMergeCoin(itemId);
+    }
+
     public static boolean isExpIncrease(int itemId) {
         return itemId >= 2022450 && itemId <= 2022452;
     }

--- a/src/main/java/constants/id/ItemId.java
+++ b/src/main/java/constants/id/ItemId.java
@@ -21,6 +21,80 @@ public class ItemId {
     public static final int ARPQ_SHIELD = 2022269;
     public static final int ROARING_TIGER_MESSENGER = 5390006;
 
+    private static boolean intInRange(int testNumber, int low, int high) {
+        return intInRange(testNumber, low, high, true);
+    }
+
+    private static boolean intInRange(int testNumber, int low, int high, boolean inclusive) {
+        return ((testNumber > low && testNumber < high)
+                    || (inclusive && (testNumber == low || testNumber == high)));
+    }
+
+    public static boolean isOre(int itemId) {
+        // strengthened jewel ores: 425XX00-425XX02 (XX from 00 to 14)
+        // we also consider piece of time / rock of time as ores since they are primarily maker items
+        return (intInRange(itemId, 4007000, 4007007) // magic powder
+                || intInRange(itemId, 4010000, 4010008) // mineral ores
+                || intInRange(itemId, 4011000, 4011008) // mineral plates
+                || intInRange(itemId, 4020000, 4020008) // jewel ores
+                || intInRange(itemId, 4021000, 4021010) // refined jewels
+                || intInRange(itemId, 4260000, 4260008) // monster crystals
+                || intInRange(itemId, 4130000, 4130022) // stimulators
+                || intInRange(itemId, 4131000, 4131015) // production manuals
+                || intInRange(itemId, 4250000, 4251502) && intInRange((itemId / 100) % 100, 0, 14) && intInRange(itemId % 100, 0, 2) // strengthened jewels/crystals (see above)
+                || itemId == 4020009 // piece of time
+                || itemId == 4021010 // rock of time
+        );
+    }
+
+    public static boolean isScroll(int itemId) {
+        // scroll IDs are pretty spread out, so this is hefty
+        // refer to handbook for IDs
+        return (intInRange(itemId, 2040000, 2040031)
+                || intInRange(itemId, 2040100, 2040109)
+                || intInRange(itemId, 2040200, 2040209)
+                || intInRange(itemId, 2040300, 2040328)
+                || intInRange(itemId, 2040400, 2040427)
+                || intInRange(itemId, 2040500, 2040534)
+                || intInRange(itemId, 2040600, 2040627)
+                || intInRange(itemId, 2040700, 2040723)
+                || itemId == 2040727
+                || intInRange(itemId, 2040800, 2040825)
+                || intInRange(itemId, 2040900, 2040912)
+                || intInRange(itemId, 2040914, 2040933)
+                || intInRange(itemId, 2041000, 2041062)
+                || itemId == 2041200
+                || itemId == 2041212
+                || intInRange(itemId, 2043000, 2043013)
+                || intInRange(itemId, 2043015, 2043019)
+                || intInRange(itemId, 2043100, 2043108)
+                || intInRange(itemId, 2043110, 2043114)
+                || intInRange(itemId, 2043200, 2043208)
+                || intInRange(itemId, 2043210, 2043214)
+                || intInRange(itemId, 2043700, 2043708)
+                || intInRange(itemId, 2043800, 2043808)
+                || intInRange(itemId, 2044000, 2044008)
+                || intInRange(itemId, 2044100, 2044108)
+                || intInRange(itemId, 2044110, 2044114)
+                || intInRange(itemId, 2044200, 2044208)
+                || intInRange(itemId, 2044210, 2044214)
+                || intInRange(itemId, 2044300, 2044308)
+                || intInRange(itemId, 2044310, 2044314)
+                || intInRange(itemId, 2044410, 2044414)
+                || intInRange(itemId, 2044500, 2044508)
+                || intInRange(itemId, 2044600, 2044608)
+                || intInRange(itemId, 2044700, 2044708)
+                || intInRange(itemId, 2044800, 2044810)
+                || intInRange(itemId, 2048000, 2048013)
+                || intInRange(itemId, 2049000, 2049003)
+                || itemId == 2049100
+        );
+    }
+
+    public static boolean isMergeCoin(int itemId) {
+        return itemId == MERGE_COIN;
+    }
+
     public static boolean isExpIncrease(int itemId) {
         return itemId >= 2022450 && itemId <= 2022452;
     }

--- a/src/main/java/constants/id/NpcId.java
+++ b/src/main/java/constants/id/NpcId.java
@@ -37,4 +37,5 @@ public class NpcId {
 
     public static final int PLAYER_NPC_BASE = 9900000;
 
+    public static final int PLAYER_RESOURCE_STORAGE = 9201101; // T-1337
 }

--- a/src/main/java/server/ResourceStorage.java
+++ b/src/main/java/server/ResourceStorage.java
@@ -250,15 +250,6 @@ public class ResourceStorage {
             lock.unlock();
         }*/
     }
-
-    public void close() {
-        lock.lock();
-        try {
-            typeItems.clear();
-        } finally {
-            lock.unlock();
-        }
-    }
 }
 
 

--- a/src/main/java/server/ResourceStorage.java
+++ b/src/main/java/server/ResourceStorage.java
@@ -240,42 +240,6 @@ public class ResourceStorage {
         }
     }
 
-    public int getStoreFee() {  // thanks to GabrielSin
-        int npcId = currentNpcid;
-        Integer fee = trunkPutCache.get(npcId);
-        if (fee == null) {
-            fee = 100;
-
-            DataProvider npc = DataProviderFactory.getDataProvider(WZFiles.NPC);
-            Data npcData = npc.getData(npcId + ".img");
-            if (npcData != null) {
-                fee = DataTool.getIntConvert("info/trunkPut", npcData, 100);
-            }
-
-            trunkPutCache.put(npcId, fee);
-        }
-
-        return fee;
-    }
-
-    public int getTakeOutFee() {
-        int npcId = currentNpcid;
-        Integer fee = trunkGetCache.get(npcId);
-        if (fee == null) {
-            fee = 0;
-
-            DataProvider npc = DataProviderFactory.getDataProvider(WZFiles.NPC);
-            Data npcData = npc.getData(npcId + ".img");
-            if (npcData != null) {
-                fee = DataTool.getIntConvert("info/trunkGet", npcData, 0);
-            }
-
-            trunkGetCache.put(npcId, fee);
-        }
-
-        return fee;
-    }
-
     public boolean isFull() {
         return false; // ???
         /*

--- a/src/main/java/server/ResourceStorage.java
+++ b/src/main/java/server/ResourceStorage.java
@@ -1,0 +1,266 @@
+/*
+ This file is part of the OdinMS Maple Story Server
+ Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+ Matthias Butz <matze@odinms.de>
+ Jan Christian Meyer <vimes@odinms.de>
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as
+ published by the Free Software Foundation version 3 as published by
+ the Free Software Foundation. You may not use, modify or distribute
+ this program under any other version of the GNU Affero General Public
+ License.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package server;
+
+import client.Client;
+import client.inventory.InventoryType;
+import client.inventory.Item;
+import client.inventory.ItemFactory;
+import constants.game.GameConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import provider.Data;
+import provider.DataProvider;
+import provider.DataProviderFactory;
+import provider.DataTool;
+import provider.wz.WZFiles;
+import tools.DatabaseConnection;
+import tools.PacketCreator;
+import tools.Pair;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * @author Matze
+ */
+public class ResourceStorage {
+    private static final Logger log = LoggerFactory.getLogger(ResourceStorage.class);
+    private static final Map<Integer, Integer> trunkGetCache = new HashMap<>();
+    private static final Map<Integer, Integer> trunkPutCache = new HashMap<>();
+
+    private final int accountId;
+    private int currentNpcid;
+    private final int storageTypeId;
+
+    private final byte slots = Byte.MAX_VALUE;
+    private final Map<InventoryType, List<Item>> typeItems = new HashMap<>();
+    private List<Item> items = new LinkedList<>();
+    private final Lock lock = new ReentrantLock(true);
+
+    private ResourceStorage(int accountId, int storageTypeId) {
+        this.accountId = accountId;
+        this.storageTypeId = storageTypeId;
+    }
+
+    public static ResourceStorage loadFromDB(int accountId, int storageTypeId) {
+        ResourceStorage ret;
+        try (Connection con = DatabaseConnection.getConnection()) {
+            ret = new ResourceStorage(accountId, storageTypeId);
+            
+            for (Pair<Item, InventoryType> item : ItemFactory.getFactoryByValue(storageTypeId).loadItems(ret.accountId, false)) {
+                ret.items.add(item.getLeft());
+            }
+
+            return ret;
+        } catch (SQLException ex) { // exceptions leading to deploy null storages found thanks to Jefe
+            log.error("SQL error occurred when trying to load storage for accId {}", accountId, ex);
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public byte getSlots() {
+        return slots;
+    }
+
+    public boolean canGainSlots(int slots) {
+        return false;
+    }
+
+    public boolean gainSlots(int slots) {
+        return false;
+    }
+
+    public void saveToDB(Connection con) {
+        try {
+            List<Pair<Item, InventoryType>> itemsWithType = new ArrayList<>();
+
+            List<Item> list = getItems();
+            for (Item item : list) {
+                itemsWithType.add(new Pair<>(item, item.getInventoryType()));
+            }
+
+            ItemFactory.getFactoryByValue(storageTypeId).saveItems(itemsWithType, accountId, con);
+        } catch (SQLException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    public Item getItem(byte slot) {
+        lock.lock();
+        try {
+            return items.get(slot);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean takeOut(Item item) {
+        lock.lock();
+        try {
+            boolean ret = items.remove(item);
+
+            InventoryType type = item.getInventoryType();
+            typeItems.put(type, new ArrayList<>(filterItems(type)));
+
+            return ret;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean store(Item item) {
+        lock.lock();
+        try {
+            if (isFull()) { // thanks Optimist for noticing unrestricted amount of insertions here
+                return false;
+            }
+
+            items.add(item);
+
+            InventoryType type = item.getInventoryType();
+            typeItems.put(type, new ArrayList<>(filterItems(type)));
+
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public List<Item> getItems() {
+        lock.lock();
+        try {
+            return Collections.unmodifiableList(items);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private List<Item> filterItems(InventoryType type) {
+        List<Item> storageItems = getItems();
+        List<Item> ret = new LinkedList<>();
+
+        for (Item item : storageItems) {
+            if (item.getInventoryType() == type) {
+                ret.add(item);
+            }
+        }
+        return ret;
+    }
+
+    public byte getSlot(InventoryType type, byte slot) {
+        lock.lock();
+        try {
+            byte ret = 0;
+            List<Item> storageItems = getItems();
+            for (Item item : storageItems) {
+                if (item == typeItems.get(type).get(slot)) {
+                    return ret;
+                }
+                ret++;
+            }
+            return -1;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void arrangeItems(Client c) {
+        lock.lock();
+        try {
+            StorageInventory msi = new StorageInventory(c, items);
+            msi.mergeItems();
+            items = msi.sortItems();
+
+            for (InventoryType type : InventoryType.values()) {
+                typeItems.put(type, new ArrayList<>(items));
+            }
+
+            c.sendPacket(PacketCreator.arrangeStorage(slots, items));
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public int getStoreFee() {  // thanks to GabrielSin
+        int npcId = currentNpcid;
+        Integer fee = trunkPutCache.get(npcId);
+        if (fee == null) {
+            fee = 100;
+
+            DataProvider npc = DataProviderFactory.getDataProvider(WZFiles.NPC);
+            Data npcData = npc.getData(npcId + ".img");
+            if (npcData != null) {
+                fee = DataTool.getIntConvert("info/trunkPut", npcData, 100);
+            }
+
+            trunkPutCache.put(npcId, fee);
+        }
+
+        return fee;
+    }
+
+    public int getTakeOutFee() {
+        int npcId = currentNpcid;
+        Integer fee = trunkGetCache.get(npcId);
+        if (fee == null) {
+            fee = 0;
+
+            DataProvider npc = DataProviderFactory.getDataProvider(WZFiles.NPC);
+            Data npcData = npc.getData(npcId + ".img");
+            if (npcData != null) {
+                fee = DataTool.getIntConvert("info/trunkGet", npcData, 0);
+            }
+
+            trunkGetCache.put(npcId, fee);
+        }
+
+        return fee;
+    }
+
+    public boolean isFull() {
+        lock.lock();
+        try {
+            return items.size() >= slots;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void close() {
+        lock.lock();
+        try {
+            typeItems.clear();
+        } finally {
+            lock.unlock();
+        }
+    }
+}
+
+

--- a/src/main/java/server/ResourceStorage.java
+++ b/src/main/java/server/ResourceStorage.java
@@ -53,6 +53,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Matze
  */
 public class ResourceStorage {
+    public static final int ORE_OFFSET = 0;
+    public static final int SCROLL_OFFSET = 1;
+    public static final int MERGE_COIN_OFFSET = 2;
+    
     private static final Logger log = LoggerFactory.getLogger(ResourceStorage.class);
     private static final Map<Integer, Integer> trunkGetCache = new HashMap<>();
     private static final Map<Integer, Integer> trunkPutCache = new HashMap<>();


### PR DESCRIPTION
## Description
Discord thread: https://discord.com/channels/1338478839126294599/1350604964069769327

This adds an `@resources` command which spawns a resource manager NPC.  Resources are materials that are valuable to accumulate over the course of playing, but are a burden on inventory space.  For this implementation, the following items are classified as storeable resources:
- Ores, refined plates, refined jewels, strengthened jewels
- Production stimulators/manuals
- Monster crystals
- Piece of Time / Rock of Time
- Scrolls (currently excludes e.g. HTP dragon stones)
- Merge Coins (A Flurry of Snow)

Resources can be deposited and withdrawn from the NPC at will for no cost.  Resource storage is account-wide and (I believe) unlimited in amount.  When an item on the map is looted, whether via `@loot` or manual pickup, if the item is a storeable resource it will automatically be sent to storage and a message will be displayed to the user.

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [X] I have performed a self-review of my code
- [X] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
Video showing functionality below.  Separately I have tested it when you have a full inventory and as expected you will not be allowed to withdraw from storage if the appropriate inventory tab is full.

https://github.com/user-attachments/assets/ef784196-254d-4fd3-808a-0581d4ffa59c


