### PR TITLE
Additional QoL changes

### DIFF
--- a/scripts/reactor/2111001.js
+++ b/scripts/reactor/2111001.js
@@ -25,10 +25,11 @@ function act() {
         rm.getPlayer().getEventInstance().setProperty("canEnter", "false");
     }
     rm.changeMusic("Bgm06/FinalFight");
-    rm.spawnFakeMonster(8800000);
+    
     for (i = 8800003; i < 8800011; i++) {
         rm.spawnMonster(i);
     }
+    rm.spawnFakeMonster(8800000);
     rm.createMapMonitor(280030000, "ps00");
     rm.mapMessage(5, "Zakum is summoned by the force of Eye of Fire.");
 }

--- a/src/main/java/client/command/commands/gm1/GotoCommand.java
+++ b/src/main/java/client/command/commands/gm1/GotoCommand.java
@@ -27,6 +27,7 @@ import client.Character;
 import client.Client;
 import client.command.Command;
 import constants.game.GameConstants;
+import constants.id.MapId;
 import constants.id.NpcId;
 import server.maps.FieldLimit;
 import server.maps.MapFactory;
@@ -121,7 +122,13 @@ public class GotoCommand extends Command {
 
             // expedition issue with this command detected thanks to Masterrulax
             Portal targetPortal = target.getRandomPlayerSpawnpoint();
-            player.saveLocationOnWarp();
+            if (target.getId() == MapId.FM_ENTRANCE) {
+                player.saveLocation("FREE_MARKET");
+            }
+            else {
+                player.saveLocationOnWarp();
+            }
+            
             player.changeMap(target, targetPortal);
         } else {
             // detailed info on goto available areas suggested thanks to Vcoc

--- a/src/main/java/server/maps/MapleMap.java
+++ b/src/main/java/server/maps/MapleMap.java
@@ -1937,7 +1937,7 @@ public class MapleMap {
     }
 
     private void applyChannelBuff(final Monster monster) {
-        if (channel == 3) {
+        if (channel == 3 && !monster.isBoss()) {
             long newHp = (long)monster.getHp() * 5;
             if (newHp > 2_000_000_000) {
                 // Calculate how much HP to add to reach exactly 2 billion

--- a/src/main/java/server/maps/MapleMap.java
+++ b/src/main/java/server/maps/MapleMap.java
@@ -1936,9 +1936,8 @@ public class MapleMap {
         }
     }
 
-    public void spawnMonster(final Monster monster) {
-        if (channel == 3)
-        {
+    private void applyChannelBuff(final Monster monster) {
+        if (channel == 3) {
             long newHp = (long)monster.getHp() * 5;
             if (newHp > 2_000_000_000) {
                 // Calculate how much HP to add to reach exactly 2 billion
@@ -1950,6 +1949,10 @@ public class MapleMap {
             }
             monster.setStartingHp(monster.getHp());
         }
+    }
+
+    public void spawnMonster(final Monster monster) {
+        applyChannelBuff(monster);
         spawnMonster(monster, 1, false);
     }
 
@@ -2037,6 +2040,7 @@ public class MapleMap {
     }
 
     public void spawnFakeMonster(final Monster monster) {
+        applyChannelBuff(monster);
         monster.setMap(this);
         monster.setFake(true);
         spawnAndAddRangedMapObject(monster, c -> c.sendPacket(PacketCreator.spawnFakeMonster(monster, 0)));

--- a/src/main/java/server/maps/MapleMap.java
+++ b/src/main/java/server/maps/MapleMap.java
@@ -1948,6 +1948,7 @@ public class MapleMap {
                 // Original calculation is fine, multiply by 5
                 monster.addHp(monster.getHp() * 4); // Add 4 times current HP since addHp adds to current value
             }
+            monster.setStartingHp(monster.getHp());
         }
         spawnMonster(monster, 1, false);
     }


### PR DESCRIPTION
## Description
- MTS/Trade button now warps to FM (follows same rules for being able to `@goto fm`)
- Updates FM warping so that your previous location is saved, and you will correctly return to your previous map (no more wasting tele rocks)
- Sets the monster max/starting HP appropriately for buffed channels (fixes `@mobhp` display value, HP bars, ).  Also prevents exploitable XP issue with mobs that heal themselves
  - There is still an issue where a mob that heals itself will reward LESS XP than expected, but that's better than rewarding MAX_INT XP :-)
- Includes fake monster spawns (e.g. Zakum1 body while arms are up) in buffs
- Keeps the check for only applying buff to non-boss monsters

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
