### PR TITLE
Corrupt

### DIFF
--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -10705,12 +10705,12 @@ public class Character extends AbstractCharacterObject {
             nEquip.setHands(newCorruption); // Updates stats via setCorruption
     
             // Messages
-            if (newCorruption % 10 == 0 && newCorruption > 0) {
+            if (newCorruption % 10 == 0 && newCorruption > oldCorruption) {
                 c.getPlayer().yellowMessage("The equipment '" + itemName + "' has been boosted!");
             }
             // each 5 from 15 down(15,10,5)
             if (newCorruption == 5 || newCorruption == 10 || newCorruption == 15) {
-                c.getPlayer().yellowMessage("Warning: The equipment '" + itemName + "' may disappear soon!");
+                c.getPlayer().yellowMessage("Warning: The equipment '" + itemName + "'(Corruption:"+newCorruption+") will disappear at 0!");
             }
     
             // Item disappearance

--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -10681,6 +10681,50 @@ public class Character extends AbstractCharacterObject {
         }
     }
 
+    public void descreaseHands(int exp){
+        ItemInformationProvider ii = ItemInformationProvider.getInstance();
+        Client c = getClient();
+    
+        for (Item item : getUpgradeableEquipped()) {
+            if (!(item instanceof Equip)) {
+                continue;
+            }
+            Equip nEquip = (Equip) item;
+            String itemName = ii.getName(nEquip.getItemId());
+            if (itemName == null) {
+                continue;
+            }
+    
+            // Decrease corruption by 1
+            short oldCorruption = nEquip.getHands();
+            if (oldCorruption <= 0) {
+                continue; // Skip items with 0 corruption
+            }
+    
+            short newCorruption = (short) Math.max(0, oldCorruption - 1);
+            nEquip.setHands(newCorruption); // Updates stats via setCorruption
+    
+            // Messages
+            if (newCorruption % 10 == 0 && newCorruption > 0) {
+                c.getPlayer().yellowMessage("The equipment '" + itemName + "' has been boosted!");
+            }
+            // each 5 from 15 down(15,10,5)
+            if (newCorruption == 5 || newCorruption == 10 || newCorruption == 15) {
+                c.getPlayer().yellowMessage("Warning: The equipment '" + itemName + "' may disappear soon!");
+            }
+    
+            // Item disappearance
+            if (newCorruption == 0 && oldCorruption == 1) {
+                InventoryManipulator.removeFromSlot(c, InventoryType.EQUIPPED, nEquip.getPosition(), nEquip.getQuantity(), false);
+                c.getPlayer().yellowMessage("The equipment '" + itemName + "' has disappeared due to corruption!");
+                continue; // Skip further processing
+            }
+    
+            // Update item
+            forceUpdateItem(nEquip);
+        }
+    }
+
     public void showAllEquipFeatures() {
         String showMsg = "";
 

--- a/src/main/java/client/inventory/Equip.java
+++ b/src/main/java/client/inventory/Equip.java
@@ -253,7 +253,67 @@ public class Equip extends Item {
     }
 
     public void setHands(short hands) {
+        // Max hands is 100, min is 0
+        if (hands > 100) {
+            hands = 100;
+        }
+        if (hands < 0) {
+            hands = 0;
+        }
+        updateStats(hands);
         this.hands = hands;
+    }
+    
+    private void updateStats(int hands) {
+        // Get current and new tier
+        int oldTier = this.hands / 10; // Tier based on current hands
+        int newTier = hands / 10;      // Tier based on new hands
+    
+        // Calculate old multiplier relative to base stat
+        float oldMultiplier;
+        if (this.hands >= 91) {
+            // At 91–100, multiplier is 1.1^9 * 1.5 (tier 9 multiplier times 50% boost)
+            oldMultiplier = (float) Math.pow(1.1, 9) * 1.5f;
+        } else {
+            // Normal tier: multiplier is 1.1^tier
+            oldMultiplier = (float) Math.pow(1.1, oldTier);
+        }
+    
+        // Calculate new multiplier relative to base stat
+        float newMultiplier;
+        if (hands >= 91) {
+            // At 91–100, multiplier is 1.1^9 * 1.5
+            newMultiplier = (float) Math.pow(1.1, 9) * 1.5f;
+        } else {
+            // Normal tier: multiplier is 1.1^tier
+            newMultiplier = (float) Math.pow(1.1, newTier);
+        }
+    
+        // Avoid division by zero (unlikely, but safety check)
+        if (oldMultiplier == 0) {
+            oldMultiplier = 1.0f;
+        }
+    
+        // Adjust stats: divide by old multiplier, multiply by new multiplier
+        str = adjustStat(str, oldMultiplier, newMultiplier);
+        dex = adjustStat(dex, oldMultiplier, newMultiplier);
+        _int = adjustStat(_int, oldMultiplier, newMultiplier);
+        luk = adjustStat(luk, oldMultiplier, newMultiplier);
+        hp = adjustStat(hp, oldMultiplier, newMultiplier);
+        mp = adjustStat(mp, oldMultiplier, newMultiplier);
+        watk = adjustStat(watk, oldMultiplier, newMultiplier);
+        matk = adjustStat(matk, oldMultiplier, newMultiplier);
+        wdef = adjustStat(wdef, oldMultiplier, newMultiplier);
+        mdef = adjustStat(mdef, oldMultiplier, newMultiplier);
+        acc = adjustStat(acc, oldMultiplier, newMultiplier);
+        avoid = adjustStat(avoid, oldMultiplier, newMultiplier);
+        speed = adjustStat(speed, oldMultiplier, newMultiplier);
+        jump = adjustStat(jump, oldMultiplier, newMultiplier);
+    }
+    
+    private short adjustStat(short stat, float oldMultiplier, float newMultiplier) {
+        float adjusted = (stat / oldMultiplier) * newMultiplier;
+        return (short) Math.max(0, Math.round(adjusted));
     }
 
     public void setSpeed(short speed) {

--- a/src/main/java/client/inventory/Equip.java
+++ b/src/main/java/client/inventory/Equip.java
@@ -260,11 +260,11 @@ public class Equip extends Item {
         if (hands < 0) {
             hands = 0;
         }
-        updateStats(hands);
+        corruptionUpdateStats(hands);
         this.hands = hands;
     }
     
-    private void updateStats(int hands) {
+    private void corruptionUpdateStats(int hands) {
         // Get current and new tier
         int oldTier = this.hands / 10; // Tier based on current hands
         int newTier = hands / 10;      // Tier based on new hands

--- a/src/main/java/client/inventory/Equip.java
+++ b/src/main/java/client/inventory/Equip.java
@@ -293,28 +293,33 @@ public class Equip extends Item {
         if (oldMultiplier == 0) {
             oldMultiplier = 1.0f;
         }
-    
-        // Adjust stats: divide by old multiplier, multiply by new multiplier
-        str = adjustStat(str, oldMultiplier, newMultiplier);
-        dex = adjustStat(dex, oldMultiplier, newMultiplier);
-        _int = adjustStat(_int, oldMultiplier, newMultiplier);
-        luk = adjustStat(luk, oldMultiplier, newMultiplier);
-        hp = adjustStat(hp, oldMultiplier, newMultiplier);
-        mp = adjustStat(mp, oldMultiplier, newMultiplier);
-        watk = adjustStat(watk, oldMultiplier, newMultiplier);
-        matk = adjustStat(matk, oldMultiplier, newMultiplier);
-        wdef = adjustStat(wdef, oldMultiplier, newMultiplier);
-        mdef = adjustStat(mdef, oldMultiplier, newMultiplier);
-        acc = adjustStat(acc, oldMultiplier, newMultiplier);
-        avoid = adjustStat(avoid, oldMultiplier, newMultiplier);
-        speed = adjustStat(speed, oldMultiplier, newMultiplier);
-        jump = adjustStat(jump, oldMultiplier, newMultiplier);
+        // list of all stats to adjust(str, dex etc)
+        List<Short> stats = List.of(str, dex, _int, luk, hp, mp, watk, matk, wdef, mdef, acc, avoid, speed, jump);
+        // update the class real values
+        for (int i = 0; i < stats.size(); i++) {
+            short stat = stats.get(i);
+            // Calculate the new value based on the new multiplier
+            float newValue = (stat / oldMultiplier) * newMultiplier;
+            // Update the class variable with the new value
+            switch (i) {
+                case 0 -> setStr((short) newValue);
+                case 1 -> setDex((short) newValue);
+                case 2 -> setInt((short) newValue);
+                case 3 -> setLuk((short) newValue);
+                case 4 -> setHp((short) newValue);
+                case 5 -> setMp((short) newValue);
+                case 6 -> setWatk((short) newValue);
+                case 7 -> setMatk((short) newValue);
+                case 8 -> setWdef((short) newValue);
+                case 9 -> setMdef((short) newValue);
+                case 10 -> setAcc((short) newValue);
+                case 11 -> setAvoid((short) newValue);
+                case 12 -> setSpeed((short) newValue);
+                case 13 -> setJump((short) newValue);
+            }
+        }
     }
-    
-    private short adjustStat(short stat, float oldMultiplier, float newMultiplier) {
-        float adjusted = (stat / oldMultiplier) * newMultiplier;
-        return (short) Math.max(0, Math.round(adjusted));
-    }
+
 
     public void setSpeed(short speed) {
         this.speed = speed;

--- a/src/main/java/constants/id/ItemId.java
+++ b/src/main/java/constants/id/ItemId.java
@@ -275,6 +275,7 @@ public class ItemId {
     public static final int RING_STR_100_SCROLL = 2041100;
     public static final int DRAGON_STONE_SCROLL = 2041200;
     public static final int BELT_STR_100_SCROLL = 2041300;
+    public static final int CORRUPT_15_SCROLL = 2049115;
 
     // Cure debuff
     public static final int ALL_CURE_POTION = 2050004;

--- a/src/main/java/constants/id/ItemId.java
+++ b/src/main/java/constants/id/ItemId.java
@@ -275,7 +275,7 @@ public class ItemId {
     public static final int RING_STR_100_SCROLL = 2041100;
     public static final int DRAGON_STONE_SCROLL = 2041200;
     public static final int BELT_STR_100_SCROLL = 2041300;
-    public static final int CORRUPT_15_SCROLL = 2049115;
+    public static final int CORRUPT_SCROLL = 2049115;
 
     // Cure debuff
     public static final int ALL_CURE_POTION = 2050004;

--- a/src/main/java/net/server/channel/handlers/ScrollHandler.java
+++ b/src/main/java/net/server/channel/handlers/ScrollHandler.java
@@ -83,12 +83,12 @@ public final class ScrollHandler extends AbstractPacketHandler {
                     return;
                 }
                 if (!ItemConstants.isModifierScroll(scroll.getItemId()) && 
-                    (scroll.getItemId() != ItemId.CORRUPT_15_SCROLL || toScroll.getHands() >= 100) && 
+                    (scroll.getItemId() != ItemId.CORRUPT_SCROLL || toScroll.getHands() >= 100) && 
                     toScroll.getUpgradeSlots() < 1) {
                     announceCannotScroll(c, legendarySpirit);
                     return;
                 }
-                if (ItemId.CORRUPT_15_SCROLL == scroll.getItemId() && toScroll.getHands() >= 100) {
+                if (ItemId.CORRUPT_SCROLL == scroll.getItemId() && toScroll.getHands() >= 100) {
                     c.sendPacket(PacketCreator.getInventoryFull());
                     return;
                 }
@@ -101,7 +101,7 @@ public final class ScrollHandler extends AbstractPacketHandler {
                     announceCannotScroll(c, legendarySpirit);
                     return;
                 }
-                if (!ItemConstants.isChaosScroll(scroll.getItemId()) && !ItemConstants.isCleanSlate(scroll.getItemId()) && scroll.getItemId() != ItemId.CORRUPT_15_SCROLL) {
+                if (!ItemConstants.isChaosScroll(scroll.getItemId()) && !ItemConstants.isCleanSlate(scroll.getItemId()) && scroll.getItemId() != ItemId.CORRUPT_SCROLL) {
                     if (!canScroll(scroll.getItemId(), toScroll.getItemId())) {
                         announceCannotScroll(c, legendarySpirit);
                         return;
@@ -149,7 +149,7 @@ public final class ScrollHandler extends AbstractPacketHandler {
                         } else if (scrolled.getLevel() > oldLevel ||
                         (ItemConstants.isCleanSlate(scroll.getItemId()) && scrolled.getUpgradeSlots() == oldSlots + 1) ||
                         ItemConstants.isFlagModifier(scroll.getItemId(), scrolled.getFlag()) ||
-                        (scroll.getItemId() == ItemId.CORRUPT_15_SCROLL && scrolled.getHands() > oldHands)) {
+                        (scroll.getItemId() == ItemId.CORRUPT_SCROLL && scrolled.getHands() > oldHands)) {
                             scrollSuccess = Equip.ScrollResult.SUCCESS;
                             successfulScrolls++;
                         }

--- a/src/main/java/net/server/channel/handlers/ScrollHandler.java
+++ b/src/main/java/net/server/channel/handlers/ScrollHandler.java
@@ -82,8 +82,14 @@ public final class ScrollHandler extends AbstractPacketHandler {
                     announceCannotScroll(c, legendarySpirit);
                     return;
                 }
-                if (!ItemConstants.isModifierScroll(scroll.getItemId()) && toScroll.getUpgradeSlots() < 1) {
+                if (!ItemConstants.isModifierScroll(scroll.getItemId()) && 
+                    (scroll.getItemId() != ItemId.CORRUPT_15_SCROLL || toScroll.getHands() >= 100) && 
+                    toScroll.getUpgradeSlots() < 1) {
                     announceCannotScroll(c, legendarySpirit);
+                    return;
+                }
+                if (ItemId.CORRUPT_15_SCROLL == scroll.getItemId() && toScroll.getHands() >= 100) {
+                    c.sendPacket(PacketCreator.getInventoryFull());
                     return;
                 }
                 List<Integer> scrollReqs = ii.getScrollReqs(scroll.getItemId());
@@ -95,7 +101,7 @@ public final class ScrollHandler extends AbstractPacketHandler {
                     announceCannotScroll(c, legendarySpirit);
                     return;
                 }
-                if (!ItemConstants.isChaosScroll(scroll.getItemId()) && !ItemConstants.isCleanSlate(scroll.getItemId())) {
+                if (!ItemConstants.isChaosScroll(scroll.getItemId()) && !ItemConstants.isCleanSlate(scroll.getItemId()) && scroll.getItemId() != ItemId.CORRUPT_15_SCROLL) {
                     if (!canScroll(scroll.getItemId(), toScroll.getItemId())) {
                         announceCannotScroll(c, legendarySpirit);
                         return;
@@ -133,19 +139,20 @@ public final class ScrollHandler extends AbstractPacketHandler {
                         // Regular scrolling: only 1 scroll
                         byte oldLevel = currentEquip.getLevel();
                         byte oldSlots = currentEquip.getUpgradeSlots();
+                        short oldHands = currentEquip.getHands();
 
                         Equip scrolled = (Equip) ii.scrollEquipWithId(currentEquip, scroll.getItemId(), whiteScroll, 0, chr.isGM(), chr.accountExtraDetails.getAscension().contains(AscensionConstants.Names.LUCKY));
                         ScrollResult scrollSuccess = Equip.ScrollResult.FAIL;
 
                         if (scrolled == null) {
                             scrollSuccess = Equip.ScrollResult.CURSE;
-                        } else if (scrolled.getLevel() > oldLevel || 
-                                 (ItemConstants.isCleanSlate(scroll.getItemId()) && scrolled.getUpgradeSlots() == oldSlots + 1) || 
-                                 ItemConstants.isFlagModifier(scroll.getItemId(), scrolled.getFlag())) {
+                        } else if (scrolled.getLevel() > oldLevel ||
+                        (ItemConstants.isCleanSlate(scroll.getItemId()) && scrolled.getUpgradeSlots() == oldSlots + 1) ||
+                        ItemConstants.isFlagModifier(scroll.getItemId(), scrolled.getFlag()) ||
+                        (scroll.getItemId() == ItemId.CORRUPT_15_SCROLL && scrolled.getHands() > oldHands)) {
                             scrollSuccess = Equip.ScrollResult.SUCCESS;
                             successfulScrolls++;
                         }
-
                         scrollsUsed = 1;
 
                         if (scrollSuccess == Equip.ScrollResult.CURSE && !ItemId.isWeddingRing(currentEquip.getItemId())) {

--- a/src/main/java/server/ItemInformationProvider.java
+++ b/src/main/java/server/ItemInformationProvider.java
@@ -1062,8 +1062,7 @@ public class ItemInformationProvider {
 
         if (equip instanceof Equip nEquip) {
             Map<String, Integer> stats = this.getEquipStats(scrollId);
-
-            if (((nEquip.getUpgradeSlots() > 0 || ItemConstants.isCleanSlate(scrollId))) || assertGM) {
+            if (nEquip.getUpgradeSlots() > 0 || ItemConstants.isCleanSlate(scrollId) || scrollId == ItemId.CORRUPT_15_SCROLL || assertGM) {
                 double prop = (double) stats.get("success");
                 switch (vegaItemId) {
                     case ItemId.VEGAS_SPELL_10:
@@ -1105,19 +1104,21 @@ public class ItemInformationProvider {
                         case ItemId.MAPLE_SYRUP:
                             scrollEquipWithChaos(nEquip, YamlConfig.config.server.CHSCROLL_STAT_RANGE);
                             break;
-
+                        case ItemId.CORRUPT_15_SCROLL:
+                            nEquip.setHands((byte) (nEquip.getHands() + 10));
+                            break;
                         default:
                             improveEquipStats(nEquip, stats);
                             break;
                     }
-                    if (!ItemConstants.isCleanSlate(scrollId)) {
+                    if (!ItemConstants.isCleanSlate(scrollId) && scrollId != ItemId.CORRUPT_15_SCROLL) {
                         if (!assertGM && !ItemConstants.isModifierScroll(scrollId)) {   // issue with modifier scrolls taking slots found thanks to Masterrulax, justin, BakaKnyx
                             nEquip.setUpgradeSlots((byte) (nEquip.getUpgradeSlots() - 1));
                         }
                         nEquip.setLevel((byte) (nEquip.getLevel() + 1));
                     }
                 } else {
-                    if (!YamlConfig.config.server.USE_PERFECT_SCROLLING && !usingWhiteScroll && !ItemConstants.isCleanSlate(scrollId) && !assertGM && !ItemConstants.isModifierScroll(scrollId)) {
+                    if (!YamlConfig.config.server.USE_PERFECT_SCROLLING && !usingWhiteScroll && !ItemConstants.isCleanSlate(scrollId) && !assertGM && !ItemConstants.isModifierScroll(scrollId) && scrollId != ItemId.CORRUPT_15_SCROLL) {                        
                         nEquip.setUpgradeSlots((byte) (nEquip.getUpgradeSlots() - 1));
                     }
                     if (Randomizer.nextInt(100) < stats.get("cursed")) {
@@ -1173,6 +1174,9 @@ public class ItemInformationProvider {
                     break;
                 case "MMP":
                     nEquip.setMp(getShortMaxIfOverflow(nEquip.getMp() + stat.getValue().intValue()));
+                    break;
+                case "Hands":
+                    nEquip.setHands((byte) (nEquip.getHands() + stat.getValue().intValue()));
                     break;
                 case "afterImage":
                     break;

--- a/src/main/java/server/ItemInformationProvider.java
+++ b/src/main/java/server/ItemInformationProvider.java
@@ -1105,7 +1105,7 @@ public class ItemInformationProvider {
                             scrollEquipWithChaos(nEquip, YamlConfig.config.server.CHSCROLL_STAT_RANGE);
                             break;
                         case ItemId.CORRUPT_SCROLL:
-                            nEquip.setHands((byte) (nEquip.getHands() + 10));
+                            nEquip.setHands((byte) (nEquip.getHands() + 25));
                             break;
                         default:
                             improveEquipStats(nEquip, stats);

--- a/src/main/java/server/ItemInformationProvider.java
+++ b/src/main/java/server/ItemInformationProvider.java
@@ -1062,7 +1062,7 @@ public class ItemInformationProvider {
 
         if (equip instanceof Equip nEquip) {
             Map<String, Integer> stats = this.getEquipStats(scrollId);
-            if (nEquip.getUpgradeSlots() > 0 || ItemConstants.isCleanSlate(scrollId) || scrollId == ItemId.CORRUPT_15_SCROLL || assertGM) {
+            if (nEquip.getUpgradeSlots() > 0 || ItemConstants.isCleanSlate(scrollId) || scrollId == ItemId.CORRUPT_SCROLL || assertGM) {
                 double prop = (double) stats.get("success");
                 switch (vegaItemId) {
                     case ItemId.VEGAS_SPELL_10:
@@ -1104,21 +1104,21 @@ public class ItemInformationProvider {
                         case ItemId.MAPLE_SYRUP:
                             scrollEquipWithChaos(nEquip, YamlConfig.config.server.CHSCROLL_STAT_RANGE);
                             break;
-                        case ItemId.CORRUPT_15_SCROLL:
+                        case ItemId.CORRUPT_SCROLL:
                             nEquip.setHands((byte) (nEquip.getHands() + 10));
                             break;
                         default:
                             improveEquipStats(nEquip, stats);
                             break;
                     }
-                    if (!ItemConstants.isCleanSlate(scrollId) && scrollId != ItemId.CORRUPT_15_SCROLL) {
+                    if (!ItemConstants.isCleanSlate(scrollId) && scrollId != ItemId.CORRUPT_SCROLL) {
                         if (!assertGM && !ItemConstants.isModifierScroll(scrollId)) {   // issue with modifier scrolls taking slots found thanks to Masterrulax, justin, BakaKnyx
                             nEquip.setUpgradeSlots((byte) (nEquip.getUpgradeSlots() - 1));
                         }
                         nEquip.setLevel((byte) (nEquip.getLevel() + 1));
                     }
                 } else {
-                    if (!YamlConfig.config.server.USE_PERFECT_SCROLLING && !usingWhiteScroll && !ItemConstants.isCleanSlate(scrollId) && !assertGM && !ItemConstants.isModifierScroll(scrollId) && scrollId != ItemId.CORRUPT_15_SCROLL) {                        
+                    if (!YamlConfig.config.server.USE_PERFECT_SCROLLING && !usingWhiteScroll && !ItemConstants.isCleanSlate(scrollId) && !assertGM && !ItemConstants.isModifierScroll(scrollId) && scrollId != ItemId.CORRUPT_SCROLL) {                        
                         nEquip.setUpgradeSlots((byte) (nEquip.getUpgradeSlots() - 1));
                     }
                     if (Randomizer.nextInt(100) < stats.get("cursed")) {

--- a/src/main/java/server/life/Monster.java
+++ b/src/main/java/server/life/Monster.java
@@ -750,7 +750,18 @@ public class Monster extends AbstractLoadedLife {
             }
 
             int _partyExp = expValueToInteger(partyExp);
-
+            // decrease hands for the player, base on the exp and his level, higher the level higher the change to decrease hands
+            int totalExp = _personalExp + _partyExp;
+            int level = attacker.getLevel();
+            double levelMultiplier = level / 100.0;
+            double baseChance = totalExp * 0.00000003;
+            double chance = Math.min(baseChance * levelMultiplier, 0.5);
+            System.out.println("Chance to decrease hands: " + chance + ", Total exp: " + totalExp + ", Level: " + level + ", Level multiplier: " + levelMultiplier + ", Base chance: " + baseChance);
+            
+            if (Math.random() < chance) {
+                attacker.descreaseHands(1);
+            }
+            
             attacker.gainExp(_personalExp, _partyExp, true, false, white);
             attacker.increaseEquipExp(_personalExp);
             attacker.raiseQuestMobCount(getId());

--- a/src/main/java/server/life/Monster.java
+++ b/src/main/java/server/life/Monster.java
@@ -756,7 +756,6 @@ public class Monster extends AbstractLoadedLife {
             double levelMultiplier = level / 100.0;
             double baseChance = totalExp * 0.00000003;
             double chance = Math.min(baseChance * levelMultiplier, 0.5);
-            System.out.println("Chance to decrease hands: " + chance + ", Total exp: " + totalExp + ", Level: " + level + ", Level multiplier: " + levelMultiplier + ", Base chance: " + baseChance);
             
             if (Math.random() < chance) {
                 attacker.descreaseHands(1);

--- a/wz/Item.wz/Consume/0204.img.xml
+++ b/wz/Item.wz/Consume/0204.img.xml
@@ -368,7 +368,7 @@
       <uol name="iconRaw" value="../../02040002/info/iconRaw"/>
       <int name="price" value="1"/>
       <int name="incHands" value="10"/>
-      <int name="success" value="15"/>
+      <int name="success" value="100"/>
     </imgdir>
   </imgdir>
   <imgdir name="02040041">

--- a/wz/Item.wz/Consume/0204.img.xml
+++ b/wz/Item.wz/Consume/0204.img.xml
@@ -362,6 +362,15 @@
       <int name="success" value="10"/>
     </imgdir>
   </imgdir>
+  <imgdir name="02049115">
+    <imgdir name="info">
+      <uol name="icon" value="../../02040002/info/icon"/>
+      <uol name="iconRaw" value="../../02040002/info/iconRaw"/>
+      <int name="price" value="1"/>
+      <int name="incHands" value="10"/>
+      <int name="success" value="15"/>
+    </imgdir>
+  </imgdir>
   <imgdir name="02040041">
     <imgdir name="info">
       <canvas name="icon" width="30" height="30">

--- a/wz/String.wz/Consume.img.xml
+++ b/wz/String.wz/Consume.img.xml
@@ -1635,6 +1635,10 @@
     <string name="name" value="Scroll for Helmet for DEX 10%"/>
     <string name="desc" value="Improves DEX on headwear.\nSuccess rate:10%, DEX+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
+  <imgdir name="2049115">
+    <string name="name" value="Scroll for Corrupt 15%"/>
+    <string name="desc" value="Improves Corrupt.\nSuccess rate:15%, CORRUPT+10."/>
+  </imgdir>
   <imgdir name="2040100">
     <string name="name" value="Scroll for Face Accessory for HP"/>
     <string name="desc" value="Improves MaxHP on face accessories.\nSuccess rate:10%, MaxHP+30. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>

--- a/wz/String.wz/Consume.img.xml
+++ b/wz/String.wz/Consume.img.xml
@@ -1636,8 +1636,8 @@
     <string name="desc" value="Improves DEX on headwear.\nSuccess rate:10%, DEX+3. The success rate of this scroll can be enhanced by Vega&apos;s Spell."/>
   </imgdir>
   <imgdir name="2049115">
-    <string name="name" value="Scroll for Corrupt 15%"/>
-    <string name="desc" value="Improves Corrupt.\nSuccess rate:15%, CORRUPT+10."/>
+    <string name="name" value="Scroll for Corruption 100%"/>
+    <string name="desc" value="Improves Corruption.\nSuccess rate:100%, CORRUPT+10."/>
   </imgdir>
   <imgdir name="2040100">
     <string name="name" value="Scroll for Face Accessory for HP"/>


### PR DESCRIPTION
##  New Feature: Equipment Corruption System

### Summary

This PR introduces a new **Equipment Corruption** system designed to add **risk-versus-reward** mechanics to gear progression.

---

### What's New

- Introduced **Corrupt Scrolls** that allow players to **corrupt equipment**.
- For every **10 points of corruption**, the equipment receives a **+10% stat boost**.
- At the final corruption tier (**91–100**), equipment gains an **extra +50% boost** to **each stat**.
-  **If an item's corruption reaches 0, it will be permanently destroyed.**
- Corruption levels **gradually decrease** while hunting monsters, encouraging players to maintain their gear regularly.

---

### Gameplay Impact

This system adds a strategic layer to gear enhancement:

- Promotes **risk-taking** for powerful rewards.
- Adds **maintenance mechanics** to sustain equipment boosts.
- Encourages **resource management** and **timing** for optimal performance.

